### PR TITLE
Implement DB-backed API with JWT auth and audit logging

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import User
+
+SECRET_KEY = "secret"  # in production load from env
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
+
+
+def authenticate_user(db: Session, username: str, password: str) -> Optional[User]:
+    user = db.query(User).filter(User.username == username).first()
+    if user and verify_password(password, user.hashed_password):
+        return user
+    return None
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+async def get_current_user(
+    token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)
+):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = db.query(User).filter(User.username == username).first()
+    if user is None:
+        raise credentials_exception
+    return user
+
+
+def require_role(required_roles):
+    def role_dependency(user: User = Depends(get_current_user)):
+        if user.role not in required_roles:
+            raise HTTPException(status_code=403, detail="Not enough privileges")
+        return user
+
+    return role_dependency
+
+
+async def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)
+):
+    user = authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(
+        data={"sub": user.username}, expires_delta=access_token_expires
+    )
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/database.py
+++ b/database.py
@@ -1,0 +1,25 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./inventory.db")
+
+if DATABASE_URL.startswith("sqlite"):  # dev mode
+    engine = create_engine(
+        DATABASE_URL, connect_args={"check_same_thread": False}
+    )
+else:
+    engine = create_engine(DATABASE_URL)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/inventory.py
+++ b/inventory.py
@@ -6,38 +6,44 @@ from inventory_core import (
     return_item as core_return_item,
     get_status,
 )
+from database import SessionLocal, engine
+from models import Base
+
+Base.metadata.create_all(bind=engine)
 
 
-def add_item(name: str, qty: int, threshold: int):
-    item = core_add_item(name, qty, threshold)
-    print(f"Added {qty} {name}(s). Available: {item['available']}")
+def add_item(db, name: str, qty: int, threshold: int):
+    item = core_add_item(db, name, qty, threshold)
+    print(
+        f"Added {qty} {name}(s). Available: {item.available}"
+    )
 
 
-def issue_item(name: str, qty: int):
+def issue_item(db, name: str, qty: int):
     try:
-        item = core_issue_item(name, qty)
-        print(f"Issued {qty} {name}(s). In use: {item['in_use']}")
+        item = core_issue_item(db, name, qty)
+        print(f"Issued {qty} {name}(s). In use: {item.in_use}")
     except ValueError:
         print('Not enough stock to issue')
 
 
-def return_item(name: str, qty: int):
+def return_item(db, name: str, qty: int):
     try:
-        item = core_return_item(name, qty)
-        print(f"Returned {qty} {name}(s). Available: {item['available']}")
+        item = core_return_item(db, name, qty)
+        print(f"Returned {qty} {name}(s). Available: {item.available}")
     except ValueError:
         print('Invalid return quantity')
 
 
-def status(name: str = None):
-    items = get_status(name)
+def status(db, name: str = None):
+    items = get_status(db, name)
     if not items:
         print('No items found')
         return
     for k, item in items.items():
-        available = item['available']
-        in_use = item['in_use']
-        threshold = item.get('threshold', 0)
+        available = item["available"]
+        in_use = item["in_use"]
+        threshold = item.get("threshold", 0)
         print(f"{k}: available={available}, in_use={in_use}, threshold={threshold}")
         if available < threshold:
             print(f"  WARNING: {k} stock below threshold")
@@ -65,16 +71,20 @@ def main():
 
     args = parser.parse_args()
 
-    if args.command == 'add':
-        add_item(args.name, args.quantity, args.threshold or 0)
-    elif args.command == 'issue':
-        issue_item(args.name, args.quantity)
-    elif args.command == 'return':
-        return_item(args.name, args.quantity)
-    elif args.command == 'status':
-        status(args.name)
-    else:
-        parser.print_help()
+    db = SessionLocal()
+    try:
+        if args.command == 'add':
+            add_item(db, args.name, args.quantity, args.threshold or 0)
+        elif args.command == 'issue':
+            issue_item(db, args.name, args.quantity)
+        elif args.command == 'return':
+            return_item(db, args.name, args.quantity)
+        elif args.command == 'status':
+            status(db, args.name)
+        else:
+            parser.print_help()
+    finally:
+        db.close()
 
 if __name__ == '__main__':
     main()

--- a/inventory_core.py
+++ b/inventory_core.py
@@ -1,61 +1,68 @@
-import json
-import os
-from typing import Dict
-
-DATA_FILE = 'inventory.json'
-
-
-def load_data() -> Dict[str, dict]:
-    if not os.path.exists(DATA_FILE):
-        return {}
-    with open(DATA_FILE, 'r') as f:
-        try:
-            return json.load(f)
-        except json.JSONDecodeError:
-            return {}
+from typing import Dict, Optional
+from sqlalchemy.orm import Session
+from models import Item, AuditLog
+from datetime import datetime
 
 
-def save_data(data: Dict[str, dict]):
-    with open(DATA_FILE, 'w') as f:
-        json.dump(data, f, indent=2)
+def _log_action(db: Session, user_id: Optional[int], item: Item, action: str, quantity: int):
+    log = AuditLog(user_id=user_id, item_id=item.id, action=action, quantity=quantity, timestamp=datetime.utcnow())
+    db.add(log)
+    db.commit()
 
 
-def add_item(name: str, qty: int, threshold: int) -> dict:
-    data = load_data()
-    item = data.get(name, {"available": 0, "in_use": 0, "threshold": threshold})
-    item["available"] += qty
+def add_item(db: Session, name: str, qty: int, threshold: int, user_id: Optional[int] = None) -> Item:
+    item = db.query(Item).filter(Item.name == name).first()
+    if not item:
+        item = Item(name=name, available=0, in_use=0, threshold=threshold)
+        db.add(item)
+    item.available += qty
     if threshold is not None:
-        item["threshold"] = threshold
-    data[name] = item
-    save_data(data)
+        item.threshold = threshold
+    db.commit()
+    db.refresh(item)
+    _log_action(db, user_id, item, "add", qty)
     return item
 
 
-def issue_item(name: str, qty: int) -> dict:
-    data = load_data()
-    item = data.get(name)
-    if not item or item["available"] < qty:
+def issue_item(db: Session, name: str, qty: int, user_id: Optional[int] = None) -> Item:
+    item = db.query(Item).filter(Item.name == name).first()
+    if not item or item.available < qty:
         raise ValueError("Not enough stock to issue")
-    item["available"] -= qty
-    item["in_use"] += qty
-    save_data(data)
+    item.available -= qty
+    item.in_use += qty
+    db.commit()
+    db.refresh(item)
+    _log_action(db, user_id, item, "issue", qty)
     return item
 
 
-def return_item(name: str, qty: int) -> dict:
-    data = load_data()
-    item = data.get(name)
-    if not item or item["in_use"] < qty:
+def return_item(db: Session, name: str, qty: int, user_id: Optional[int] = None) -> Item:
+    item = db.query(Item).filter(Item.name == name).first()
+    if not item or item.in_use < qty:
         raise ValueError("Invalid return quantity")
-    item["in_use"] -= qty
-    item["available"] += qty
-    save_data(data)
+    item.in_use -= qty
+    item.available += qty
+    db.commit()
+    db.refresh(item)
+    _log_action(db, user_id, item, "return", qty)
     return item
 
 
-def get_status(name: str = None) -> Dict[str, dict]:
-    data = load_data()
+def get_status(db: Session, name: Optional[str] = None) -> Dict[str, dict]:
+    items = {}
     if name:
-        item = data.get(name)
-        return {name: item} if item else {}
-    return data
+        item = db.query(Item).filter(Item.name == name).first()
+        if item:
+            items[item.name] = {
+                "available": item.available,
+                "in_use": item.in_use,
+                "threshold": item.threshold,
+            }
+    else:
+        for item in db.query(Item).all():
+            items[item.name] = {
+                "available": item.available,
+                "in_use": item.in_use,
+                "threshold": item.threshold,
+            }
+    return items

--- a/main.py
+++ b/main.py
@@ -1,36 +1,111 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from database import Base, engine, get_db, SessionLocal
 from inventory_core import add_item, issue_item, return_item, get_status
+from auth import login_for_access_token, require_role, get_password_hash
+from models import User
 
 app = FastAPI(title="Stock SaaS API")
 
+Base.metadata.create_all(bind=engine)
+
+
+@app.on_event("startup")
+def create_default_admin():
+    db = SessionLocal()
+    if not db.query(User).filter(User.username == "admin").first():
+        admin = User(
+            username="admin",
+            hashed_password=get_password_hash("admin"),
+            role="admin",
+        )
+        db.add(admin)
+        db.commit()
+    db.close()
+
+
+admin_or_manager = require_role(["admin", "manager"])
+any_user = require_role(["admin", "manager", "user"])
+
+
+@app.post("/token")
+async def login(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_db),
+):
+    return await login_for_access_token(form_data, db)
+
 
 @app.post("/items/add")
-def api_add_item(name: str, quantity: int, threshold: int = 0):
-    item = add_item(name, quantity, threshold)
-    return {"message": f"Added {quantity} {name}(s)", "item": item}
+def api_add_item(
+    name: str,
+    quantity: int,
+    threshold: int = 0,
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_or_manager),
+):
+    item = add_item(db, name, quantity, threshold, user_id=user.id)
+    return {"message": f"Added {quantity} {name}(s)", "item": {
+        "available": item.available,
+        "in_use": item.in_use,
+        "threshold": item.threshold,
+    }}
 
 
 @app.post("/items/issue")
-def api_issue_item(name: str, quantity: int):
+def api_issue_item(
+    name: str,
+    quantity: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_or_manager),
+):
     try:
-        item = issue_item(name, quantity)
-        return {"message": f"Issued {quantity} {name}(s)", "item": item}
+        item = issue_item(db, name, quantity, user_id=user.id)
+        return {
+            "message": f"Issued {quantity} {name}(s)",
+            "item": {
+                "available": item.available,
+                "in_use": item.in_use,
+                "threshold": item.threshold,
+            },
+        }
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
 
 @app.post("/items/return")
-def api_return_item(name: str, quantity: int):
+def api_return_item(
+    name: str,
+    quantity: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_or_manager),
+):
     try:
-        item = return_item(name, quantity)
-        return {"message": f"Returned {quantity} {name}(s)", "item": item}
+        item = return_item(db, name, quantity, user_id=user.id)
+        return {
+            "message": f"Returned {quantity} {name}(s)",
+            "item": {
+                "available": item.available,
+                "in_use": item.in_use,
+                "threshold": item.threshold,
+            },
+        }
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
 
 @app.get("/items/status")
-def api_get_status(name: str | None = None):
-    data = get_status(name)
+def api_get_status(
+    name: str | None = None,
+    db: Session = Depends(get_db),
+    user: User = Depends(any_user),
+):
+    data = get_status(db, name)
     if not data:
-        raise HTTPException(status_code=404, detail="Item not found" if name else "No items found")
+        raise HTTPException(
+            status_code=404,
+            detail="Item not found" if name else "No items found",
+        )
     return data

--- a/models.py
+++ b/models.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+
+from database import Base
+
+
+class Item(Base):
+    __tablename__ = "items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+    available = Column(Integer, default=0)
+    in_use = Column(Integer, default=0)
+    threshold = Column(Integer, default=0)
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True)
+    hashed_password = Column(String)
+    role = Column(String, default="user")
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    item_id = Column(Integer, ForeignKey("items.id"))
+    action = Column(String)
+    quantity = Column(Integer)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User")
+    item = relationship("Item")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 fastapi
 uvicorn[standard]
+SQLAlchemy
+python-jose[cryptography]
+passlib[bcrypt]
+python-multipart

--- a/schemas.py
+++ b/schemas.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class ItemBase(BaseModel):
+    name: str
+    available: int
+    in_use: int
+    threshold: int
+
+
+class ItemCreate(BaseModel):
+    name: str
+    quantity: int
+    threshold: int = 0
+
+
+class ItemResponse(ItemBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class UserBase(BaseModel):
+    username: str
+
+
+class UserCreate(UserBase):
+    password: str
+    role: str = "user"
+
+
+class UserResponse(UserBase):
+    id: int
+    role: str
+
+    class Config:
+        orm_mode = True
+
+
+class AuditLogResponse(BaseModel):
+    id: int
+    user_id: int
+    item_id: int
+    action: str
+    quantity: int
+    timestamp: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- migrate storage from JSON to a SQL database
- add SQLAlchemy models including audit log
- implement JWT authentication and role checks
- update CLI and API routes to use the database
- add required dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b23d0a04833189694044be7de699