### PR TITLE
Add starter Next.js frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,18 @@ uvicorn main:app --reload
 
 API endpoints mirror the CLI commands and are documented at `/docs` when the server is running.
 Authenticate by posting your username and password to `/token` and include the returned token using `Authorization: Bearer <token>`.
+
+## Running the Frontend
+
+A simple Next.js interface lives in the `frontend/` folder. It uses the API server described above.
+
+```bash
+# install frontend dependencies
+cd frontend && npm install
+
+# start the development server
+npm run dev
+```
+
+By default it expects the FastAPI backend to run on `http://localhost:8000`. You can change this by setting `NEXT_PUBLIC_API_URL` when starting the Next.js server.
+

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+out

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,30 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+export async function login(username: string, password: string): Promise<string> {
+  const res = await fetch(`${API_URL}/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({ username, password }),
+  });
+
+  if (!res.ok) {
+    throw new Error('Login failed');
+  }
+  const data = await res.json();
+  return data.access_token as string;
+}
+
+export async function getItems(token: string) {
+  const res = await fetch(`${API_URL}/items/status`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to load');
+  }
+  return res.json();
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types='next' />\n/// <reference types='next/types/global' />

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "stock-saas-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2",
+    "@types/react": "18.2.0",
+    "@types/node": "20.4.2"
+  }
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { getItems } from '../lib/api';
+
+export default function Home() {
+  const [items, setItems] = useState<any[]>([]);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) return;
+    getItems(token)
+      .then(setItems)
+      .catch(() => setError('Failed to load inventory'));
+  }, []);
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Inventory Dashboard</h1>
+      {error && <p>{error}</p>}
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Available</th>
+            <th>In Use</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.name}>
+              <td>{item.name}</td>
+              <td>{item.available}</td>
+              <td>{item.in_use}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { login } from '../lib/api';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      const token = await login(username, password);
+      localStorage.setItem('token', token);
+      router.push('/');
+    } catch {
+      setError('Invalid credentials');
+    }
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Login</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="username">Username</label>
+          <input
+            id="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </div>
+        <div>
+          <label htmlFor="password">Password</label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <button type="submit">Login</button>
+      </form>
+      {error && <p>{error}</p>}
+    </div>
+  );
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a simple Next.js project in `frontend/`
- add login and inventory dashboard pages
- provide helper functions for API calls
- document how to run the frontend in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841402c98308331b808e8eff97adc75