### PR TITLE
Load SECRET_KEY from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ python inventory.py status
 ```
 
 Inventory data is stored in a SQLite database named `inventory.db` by default.
-Set `DATABASE_URL` to use a different database engine.
+Set `DATABASE_URL` to use a different database engine. The API also expects a
+`SECRET_KEY` environment variable used to sign JWT tokens.
 
 ## Running the API
 

--- a/auth.py
+++ b/auth.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from typing import Optional
+import os
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
@@ -10,7 +11,9 @@ from sqlalchemy.orm import Session
 from database import get_db
 from models import User
 
-SECRET_KEY = "secret"  # in production load from env
+SECRET_KEY = os.getenv("SECRET_KEY")
+if not SECRET_KEY:
+    raise RuntimeError("SECRET_KEY environment variable not set")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 


### PR DESCRIPTION
## Summary
- source SECRET_KEY from environment in `auth.py`
- document SECRET_KEY in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841415c65fc8331899897a0c7d7c662