### PR TITLE
Fix api_add_item conflict

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,18 +57,14 @@ def api_add_item(
     user: User = Depends(admin_or_manager),
 ):
 
-    item = add_item(db, item_data.name, item_data.quantity, item_data.threshold, user_id=user.id)
+    item = add_item(
+        db,
+        item_data.name,
+        item_data.quantity,
+        item_data.threshold,
+        user_id=user.id,
+    )
     return item
-=======
-    item = add_item(db, name, quantity, threshold, user_id=user.id)
-    return {
-        "message": f"Added {quantity} {name}(s)",
-        "item": {
-            "available": item.available,
-            "in_use": item.in_use,
-            "threshold": item.threshold,
-        },
-    }
 
 
 


### PR DESCRIPTION
## Summary
- resolve leftover merge conflict in api_add_item
- return created item directly

## Testing
- `pip install -r requirements.txt`
- `pip install 'httpx<0.25,>=0.24' --force-reinstall`
- `SECRET_KEY=secret pytest -q` *(fails: test_add_item_endpoint - assert 422 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_684144828cf48331b88178eb3b93a15e