### PR TITLE
Fix JSON payload in API test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,7 +33,7 @@ def get_token(client):
 def test_add_item_endpoint(client):
     token = get_token(client)
     headers = {'Authorization': f'Bearer {token}'}
-    resp = client.post('/items/add', params={'name': 'mouse', 'quantity': 2, 'threshold': 1}, headers=headers)
+    resp = client.post('/items/add', json={'name': 'mouse', 'quantity': 2, 'threshold': 1}, headers=headers)
     assert resp.status_code == 200
     assert resp.json()['item']['available'] == 2
 


### PR DESCRIPTION
## Summary
- send `/items/add` payload using `json` in tests

## Testing
- `pytest -q` *(fails: SyntaxError in `main.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68414484527c8331a3097f532e90a6f0