### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__
+.git
+tests
+frontend/node_modules
+*.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -111,3 +111,21 @@ npm run dev
 By default it expects the FastAPI backend to run on `http://localhost:8000`. You can change this by setting `NEXT_PUBLIC_API_URL` when starting the Next.js server.
 
 
+
+## Running with Docker
+
+A `Dockerfile` is provided to containerize the FastAPI service. Build and run it locally:
+
+```bash
+docker build -t stock-saas-backend .
+docker run -e SECRET_KEY=mysecret -p 8000:8000 stock-saas-backend
+```
+
+To start the backend together with a PostgreSQL database and the Next.js frontend use `docker-compose`:
+
+```bash
+docker-compose up --build
+```
+
+The API will be available on `http://localhost:8000` and the frontend on `http://localhost:3000`.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: stock
+      POSTGRES_PASSWORD: stock
+      POSTGRES_DB: stockdb
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+  backend:
+    build: .
+    environment:
+      DATABASE_URL: postgres://stock:stock@db:5432/stockdb
+      SECRET_KEY: changeme
+      ADMIN_USERNAME: admin
+      ADMIN_PASSWORD: admin
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+  frontend:
+    build:
+      context: ./frontend
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:8000
+    depends_on:
+      - backend
+    ports:
+      - "3000:3000"
+volumes:
+  postgres-data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.dockerignore
+Dockerfile

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:18-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app .
+EXPOSE 3000
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- containerize FastAPI backend
- add optional docker compose setup with PostgreSQL and frontend
- document Docker usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: TypeError: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684145662eb8833192d123d86896c6d9