### PR TITLE
Refactor inventory endpoints

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,58 +51,41 @@ async def login(
 
 
 
-@app.post("/items/add")
-=======
-@app.post("/items/add", summary="Add items to inventory")
-
+@app.post("/items/add", summary="Add items to inventory", response_model=ItemResponse)
 def api_add_item(
-    name: str,
-    quantity: int,
-    threshold: int = 0,
+    payload: ItemCreate,
     db: Session = Depends(get_db),
     user: User = Depends(admin_or_manager),
 ):
+    """Add quantity of an item to the inventory."""
+    item = add_item(db, payload.name, payload.quantity, payload.threshold, user_id=user.id)
+    return item
 
 
-
-@app.post("/items/issue")
+@app.post("/items/issue", response_model=ItemResponse)
 def api_issue_item(
-    name: str,
-    quantity: int,
+    payload: ItemCreate,
     db: Session = Depends(get_db),
     user: User = Depends(admin_or_manager),
 ):
+    """Issue quantity of an item from the inventory."""
     try:
-        item = issue_item(db, name, quantity, user_id=user.id)
-        return {
-            "message": f"Issued {quantity} {name}(s)",
-            "item": {
-                "available": item.available,
-                "in_use": item.in_use,
-                "threshold": item.threshold,
-            },
-        }
+        item = issue_item(db, payload.name, payload.quantity, user_id=user.id)
+        return item
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@app.post("/items/return")
+@app.post("/items/return", response_model=ItemResponse)
 def api_return_item(
-    name: str,
-    quantity: int,
+    payload: ItemCreate,
     db: Session = Depends(get_db),
     user: User = Depends(admin_or_manager),
 ):
+    """Return quantity of an item to the inventory."""
     try:
-        item = return_item(db, name, quantity, user_id=user.id)
-        return {
-            "message": f"Returned {quantity} {name}(s)",
-            "item": {
-                "available": item.available,
-                "in_use": item.in_use,
-                "threshold": item.threshold,
-            },
-        }
+        item = return_item(db, payload.name, payload.quantity, user_id=user.id)
+        return item
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,7 +54,9 @@ def test_add_item_endpoint(client):
     )
 
     assert resp.status_code == 200
-    assert resp.json()['available'] == 2
+    data = resp.json()
+    assert data['available'] == 2
+    assert data['name'] == 'mouse'
 
     status_resp = client.get('/items/status', params={'name': 'mouse'}, headers=headers)
     assert status_resp.status_code == 200
@@ -76,7 +78,7 @@ def test_issue_and_return_endpoints(client):
     # issue some items
     issue_resp = client.post(
         "/items/issue",
-        json={"name": "keyboard", "quantity": 3, "threshold": 0},
+        json={"name": "keyboard", "quantity": 3},
         headers=headers,
     )
     assert issue_resp.status_code == 200
@@ -87,7 +89,7 @@ def test_issue_and_return_endpoints(client):
     # return a subset
     return_resp = client.post(
         "/items/return",
-        json={"name": "keyboard", "quantity": 2, "threshold": 0},
+        json={"name": "keyboard", "quantity": 2},
         headers=headers,
     )
     assert return_resp.status_code == 200
@@ -110,7 +112,7 @@ def test_issue_return_errors(client):
     # issuing more than available should fail
     fail_issue = client.post(
         "/items/issue",
-        json={"name": "monitor", "quantity": 2, "threshold": 0},
+        json={"name": "monitor", "quantity": 2},
         headers=headers,
     )
     assert fail_issue.status_code == 400
@@ -118,7 +120,7 @@ def test_issue_return_errors(client):
     # issue one correctly
     ok_issue = client.post(
         "/items/issue",
-        json={"name": "monitor", "quantity": 1, "threshold": 0},
+        json={"name": "monitor", "quantity": 1},
         headers=headers,
     )
     assert ok_issue.status_code == 200
@@ -129,7 +131,7 @@ def test_issue_return_errors(client):
     # returning more than in_use should fail
     fail_return = client.post(
         "/items/return",
-        json={"name": "monitor", "quantity": 2, "threshold": 0},
+        json={"name": "monitor", "quantity": 2},
         headers=headers,
     )
     assert fail_return.status_code == 400


### PR DESCRIPTION
## Summary
- fix merge artifact in `main.py`
- have item endpoints accept a single `ItemCreate` payload
- return `ItemResponse` objects from add/issue/return
- update tests to match new API

## Testing
- `pip install -r requirements.txt`
- `pip install 'httpx<0.24' --force-reinstall`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841c57ef0d4833182cd225a96669f3c