### PR TITLE
Pin httpx version for Starlette

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ pip install pytest
 pytest
 ```
 
+The `requirements.txt` file pins `httpx` to `<0.25` to remain compatible with
+`starlette==0.27.0`.
+
 The tests use an in-memory SQLite database so they will not modify any local data files.
 ### Example requests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ SQLAlchemy
 python-jose[cryptography]
 passlib[bcrypt]
 python-multipart
-httpx
+httpx<0.25


### PR DESCRIPTION
## Summary
- pin `httpx` version in requirements to stay compatible with `starlette==0.27.0`
- document pinned version in README

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c898dcc083318f8ff8190921392f