### PR TITLE
Add CORS middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ npm run dev
 
 By default it expects the FastAPI backend to run on `http://localhost:8000`. You can change this by setting `NEXT_PUBLIC_API_URL` when starting the Next.js server.
 
+The backend now enables CORS using FastAPI's `CORSMiddleware`. When the
+application runs with the default SQLite database (development mode), all
+origins are allowed. In other environments requests are only accepted from the
+origin specified in `NEXT_PUBLIC_API_URL`.
+
 After logging in you will see the dashboard listing all items. Links are provided to pages for adding new stock, issuing items and recording returns. Each form uses the JWT token stored in `localStorage` to authenticate API requests.
 
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 
 from fastapi import FastAPI, HTTPException, Depends
 from fastapi.security import OAuth2PasswordRequestForm
+from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
 from database import Base, engine, get_db, SessionLocal, DATABASE_URL
@@ -11,6 +12,21 @@ from models import User
 from schemas import ItemCreate, ItemResponse, AuditLogResponse
 
 app = FastAPI(title="Stock SaaS API")
+
+# configure CORS so the frontend can access the API
+frontend_origin = os.getenv("NEXT_PUBLIC_API_URL")
+origins = [frontend_origin] if frontend_origin else []
+if DATABASE_URL.startswith("sqlite"):
+    # allow everything during local development and tests
+    origins = ["*"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 Base.metadata.create_all(bind=engine)
 


### PR DESCRIPTION
## Summary
- allow cross origin requests using `CORSMiddleware`
- document CORS behavior in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841c89f88c88331a1b98fee23eda69a