### PR TITLE
Add admin user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ origin specified in `NEXT_PUBLIC_API_URL`.
 
 After logging in you will see the dashboard listing all items. Links are provided to pages for adding new stock, issuing items and recording returns. Each form uses the JWT token stored in `localStorage` to authenticate API requests.
 
+Admins can also open `/users` to manage accounts. The page lists existing users and includes a form to create new ones.
+
 
 
 ## Running with Docker

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -73,3 +73,34 @@ export async function returnItem(token: string, item: { name: string; quantity: 
   }
   return res.json();
 }
+
+export async function createUser(
+  token: string,
+  user: { username: string; password: string; role: string }
+) {
+  const res = await fetch(`${API_URL}/users/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(user),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to create user');
+  }
+  return res.json();
+}
+
+export async function listUsers(token: string) {
+  const res = await fetch(`${API_URL}/users/`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to load users');
+  }
+  return res.json();
+}

--- a/frontend/pages/users.tsx
+++ b/frontend/pages/users.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { listUsers, createUser } from '../lib/api';
+
+export default function UsersPage() {
+  const router = useRouter();
+  const [users, setUsers] = useState<any[]>([]);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState('user');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      router.push('/login');
+      return;
+    }
+    listUsers(token)
+      .then(setUsers)
+      .catch(() => router.push('/login'));
+  }, [router]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const token = localStorage.getItem('token');
+    if (!token) {
+      setError('Not authenticated');
+      return;
+    }
+    try {
+      await createUser(token, { username, password, role });
+      const updated = await listUsers(token);
+      setUsers(updated);
+      setUsername('');
+      setPassword('');
+      setRole('user');
+    } catch {
+      setError('Failed to create user');
+    }
+  }
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Manage Users</h1>
+      <form onSubmit={handleSubmit} style={{ marginBottom: 20 }}>
+        <div>
+          <label htmlFor="username">Username</label>
+          <input id="username" value={username} onChange={(e) => setUsername(e.target.value)} />
+        </div>
+        <div>
+          <label htmlFor="password">Password</label>
+          <input id="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        </div>
+        <div>
+          <label htmlFor="role">Role</label>
+          <select id="role" value={role} onChange={(e) => setRole(e.target.value)}>
+            <option value="admin">admin</option>
+            <option value="manager">manager</option>
+            <option value="user">user</option>
+          </select>
+        </div>
+        <button type="submit">Create User</button>
+      </form>
+      {error && <p>{error}</p>}
+      <h2>Existing Users</h2>
+      <ul>
+        {users.map((u) => (
+          <li key={u.id}>{u.username} - {u.role}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expose `/users/` from the frontend API client
- add a new `users` page to create and list users
- mention the new page in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cae5f3248331a6810600bafe3001