### PR TITLE
Add AGENTS docs for frontend and tests

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,15 @@
+# frontend-agent Instructions
+
+This directory contains the Next.js interface managed by the **frontend-agent**.
+
+## Responsibilities
+- Build pages for login, inventory dashboard and item management.
+- Use components from V0.dev or simple React components.
+- Integrate with the backend API defined by the backend-agent.
+
+## Development notes
+- Install dependencies with `npm install`.
+- Start the development server using `npm run dev`.
+- The API base URL defaults to `http://localhost:8000` but can be overridden via `NEXT_PUBLIC_API_URL`.
+- Keep components simple and avoid heavy UI frameworks.
+

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,13 @@
+# test-agent Instructions
+
+This folder contains pytest suites driven by the **test-agent**.
+
+## Responsibilities
+- Validate the backend API and core logic.
+- Simulate common user flows triggered by the frontend-agent.
+
+## Running tests
+- Install Python dependencies from `requirements.txt` and `pytest`.
+- Execute all tests with `pytest` from the repository root.
+- Tests rely on an in-memory SQLite database and will not affect local data files.
+


### PR DESCRIPTION
## Summary
- add instructions for the frontend agent
- document test-agent responsibilities

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841cd35e5108331a0fdf2ed29810ec7