### PR TITLE
Fix README httpx version

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pip install pytest
 pytest
 ```
 
-The `requirements.txt` file pins `httpx` to `<0.25` to remain compatible with
+The `requirements.txt` file pins `httpx` to `0.27.*` to remain compatible with
 `starlette==0.27.0`.
 
 The tests use an in-memory SQLite database so they will not modify any local data files.


### PR DESCRIPTION
## Summary
- update README to pin `httpx` to `0.27.*`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cd8a8e708331b0a1f39cbdbad91d