### PR TITLE
Add dotenv support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment configuration for Stock-Saas
+DATABASE_URL=sqlite:///./inventory.db
+SECRET_KEY=changeme
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=admin
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/auth.py
+++ b/auth.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from typing import Optional
 import os
+from dotenv import load_dotenv
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
@@ -10,6 +11,8 @@ from sqlalchemy.orm import Session
 
 from database import get_db
 from models import User
+
+load_dotenv()
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 if not SECRET_KEY:

--- a/database.py
+++ b/database.py
@@ -1,6 +1,9 @@
 import os
+from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
+
+load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./inventory.db")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ python-multipart
 
 httpx==0.27.*
 
+python-dotenv
+


### PR DESCRIPTION
## Summary
- load variables from a `.env` file on startup
- document example environment variables
- include python-dotenv in dependencies

## Testing
- `pip install -r requirements.txt`
- `pip install pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cd8b8420833190a76ff8d996519f