### PR TITLE
Enable async CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,17 @@ curl -H "Authorization: Bearer <token>" \
   'http://localhost:8000/audit/logs?limit=5'
 ```
 
-You can also export the same data as CSV for reporting:
+You can also export the same data as CSV for reporting. The export runs in the
+background so large reports do not block the request:
 
 ```bash
+# start the export and note the returned task_id
+curl -X POST -H "Authorization: Bearer <token>" \
+  'http://localhost:8000/analytics/audit/export?limit=100'
+
+# download the generated file using the task_id from above
 curl -H "Authorization: Bearer <token>" \
-  'http://localhost:8000/analytics/audit/export?limit=100' -o audit_log.csv
+  'http://localhost:8000/analytics/audit/export/<task_id>' -o audit_log.csv
 ```
 
 ## Running the Frontend

--- a/routers/analytics.py
+++ b/routers/analytics.py
@@ -1,32 +1,71 @@
-from fastapi import APIRouter, Depends, Response
-from sqlalchemy.orm import Session
+from fastapi import (
+    APIRouter,
+    Depends,
+    Response,
+    BackgroundTasks,
+    HTTPException,
+)
 from inventory_core import get_recent_logs
-from database import get_db
+from database import SessionLocal
 from auth import require_role
 import csv
 from io import StringIO
+import uuid
 from models import User
 
 router = APIRouter(prefix="/analytics")
 
 admin_or_manager = require_role(["admin", "manager"])
 
-@router.get("/audit/export", response_class=Response, summary="Export audit log as CSV")
-def export_audit_csv(limit: int = 100, db: Session = Depends(get_db), user: User = Depends(admin_or_manager)):
-    logs = get_recent_logs(db, limit)
-    output = StringIO()
-    writer = csv.writer(output)
-    writer.writerow(["id", "user_id", "item_id", "action", "quantity", "timestamp"])
-    for log in logs:
-        writer.writerow([
-            log.id,
-            log.user_id,
-            log.item_id,
-            log.action,
-            log.quantity,
-            log.timestamp.isoformat(),
-        ])
-    csv_data = output.getvalue()
+# store results of async exports in memory {task_id: csv_data}
+export_tasks: dict[str, str | None] = {}
+
+
+def _generate_csv(limit: int, task_id: str) -> None:
+    """Background task to build the CSV data for audit logs."""
+    db = SessionLocal()
+    try:
+        logs = get_recent_logs(db, limit)
+        output = StringIO()
+        writer = csv.writer(output)
+        writer.writerow(["id", "user_id", "item_id", "action", "quantity", "timestamp"])
+        for log in logs:
+            writer.writerow([
+                log.id,
+                log.user_id,
+                log.item_id,
+                log.action,
+                log.quantity,
+                log.timestamp.isoformat(),
+            ])
+        export_tasks[task_id] = output.getvalue()
+    finally:
+        db.close()
+
+
+@router.post("/audit/export", summary="Start async audit log CSV export")
+def start_audit_export(
+    background_tasks: BackgroundTasks,
+    limit: int = 100,
+    user: User = Depends(admin_or_manager),
+):
+    task_id = str(uuid.uuid4())
+    export_tasks[task_id] = None
+    background_tasks.add_task(_generate_csv, limit, task_id)
+    return {"task_id": task_id}
+
+
+@router.get(
+    "/audit/export/{task_id}",
+    response_class=Response,
+    summary="Download generated audit log CSV",
+)
+def get_exported_csv(task_id: str, user: User = Depends(admin_or_manager)):
+    if task_id not in export_tasks:
+        raise HTTPException(status_code=404, detail="Export not found")
+    csv_data = export_tasks[task_id]
+    if csv_data is None:
+        raise HTTPException(status_code=202, detail="Export in progress")
     headers = {"Content-Type": "text/csv"}
     return Response(content=csv_data, media_type="text/csv", headers=headers)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -156,7 +156,12 @@ def test_export_audit_csv(client):
         headers=headers,
     )
 
-    resp = client.get('/analytics/audit/export', params={'limit': 1}, headers=headers)
+    start_resp = client.post('/analytics/audit/export', params={'limit': 1}, headers=headers)
+    assert start_resp.status_code == 200
+    task_id = start_resp.json()['task_id']
+    resp = client.get(f'/analytics/audit/export/{task_id}', headers=headers)
+    if resp.status_code == 202:
+        resp = client.get(f'/analytics/audit/export/{task_id}', headers=headers)
     assert resp.status_code == 200
     assert resp.headers['content-type'].startswith('text/csv')
     lines = resp.text.strip().splitlines()


### PR DESCRIPTION
## Summary
- add background task-based audit CSV exporting
- update API tests for new async behavior
- document async audit export

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cd92437483319963cbc9f8681858