### PR TITLE
Add flake8 to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          python -m pip install -r requirements.txt
           pip install pytest
+
+      - name: Lint
+        run: flake8
 
       - name: Run backend tests
         run: pytest


### PR DESCRIPTION
## Summary
- run flake8 in the backend CI job
- ensure dependencies are installed using `python -m pip install -r requirements.txt`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a2a638b88331b20a049b370fe129