### PR TITLE
Add password reset endpoints

### DIFF
--- a/2fa_research.md
+++ b/2fa_research.md
@@ -1,0 +1,17 @@
+# 2FA Integration Research
+
+Several options exist for adding two-factor authentication to the project.
+
+## TOTP Libraries
+- **pyotp** – Small Python library for generating Time-based One-Time Passwords.
+  - Supports RFC 6238 and works with Google Authenticator and similar apps.
+  - Easy to integrate by storing a per-user secret and verifying the token on login.
+
+## External Providers
+- **Authy (Twilio)** – Provides APIs for SMS, voice or push-based 2FA.
+  - Requires account with Twilio and network calls during authentication.
+- **Duo Security** – Enterprise oriented 2FA service with Python SDK.
+  - Handles push notifications and has user/device management features.
+
+Using TOTP with `pyotp` is simple and does not require an external service, but
+an external provider like Authy could offer additional channels such as SMS.

--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ from schemas import (
 )
 from routers.users import router as users_router
 from routers.analytics import router as analytics_router
+from routers.auth import router as auth_router
 from websocket_manager import InventoryWSManager
 from rate_limiter import RateLimiter
 
@@ -77,6 +78,7 @@ app.add_middleware(BaseHTTPMiddleware, dispatch=rate_limiter)
 Base.metadata.create_all(bind=engine)
 app.include_router(users_router)
 app.include_router(analytics_router)
+app.include_router(auth_router)
 
 
 @app.websocket("/ws/inventory/{tenant_id}")

--- a/models.py
+++ b/models.py
@@ -67,3 +67,14 @@ class Notification(Base):
     timestamp = Column(DateTime, default=datetime.utcnow)
 
     item = relationship("Item")
+
+
+class PasswordResetToken(Base):
+    __tablename__ = "password_reset_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    token = Column(String, unique=True, index=True)
+    expires_at = Column(DateTime)
+
+    user = relationship("User")

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timedelta
+import secrets
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import User, PasswordResetToken
+from auth import get_password_hash
+from schemas import PasswordResetRequest, PasswordResetConfirm
+
+router = APIRouter(prefix="/auth")
+
+
+@router.post("/request-reset")
+def request_password_reset(
+    payload: PasswordResetRequest, db: Session = Depends(get_db)
+):
+    user = db.query(User).filter(User.username == payload.username).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    token = secrets.token_urlsafe(32)
+    expires = datetime.utcnow() + timedelta(hours=1)
+    db.add(PasswordResetToken(user_id=user.id, token=token, expires_at=expires))
+    db.commit()
+    return {"reset_token": token}
+
+
+@router.post("/reset-password")
+def reset_password(payload: PasswordResetConfirm, db: Session = Depends(get_db)):
+    entry = (
+        db.query(PasswordResetToken)
+        .filter(PasswordResetToken.token == payload.token)
+        .first()
+    )
+    if not entry or entry.expires_at < datetime.utcnow():
+        raise HTTPException(status_code=400, detail="Invalid or expired token")
+    user = db.query(User).filter(User.id == entry.user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    user.hashed_password = get_password_hash(payload.new_password)
+    db.delete(entry)
+    db.commit()
+    return {"detail": "Password updated"}

--- a/schemas.py
+++ b/schemas.py
@@ -93,3 +93,12 @@ class TenantResponse(TenantBase):
 
     class Config:
         orm_mode = True
+
+
+class PasswordResetRequest(BaseModel):
+    username: str
+
+
+class PasswordResetConfirm(BaseModel):
+    token: str
+    new_password: str


### PR DESCRIPTION
## Summary
- create new `PasswordResetToken` database model
- expose `/auth/request-reset` and `/auth/reset-password` endpoints
- add Pydantic schemas for password reset flows
- mount new router in `main.py`
- document 2FA research options

## Testing
- `black main.py models.py schemas.py routers/auth.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6842a2af689c83318acd3c5c176d2bb6