### PR TITLE
Add quickstart script

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ cp .env.example .env
 docker-compose up --build
 ```
 
+Alternatively run `./scripts/quickstart.sh` to start all services.
+
 The compose file also starts Redis along with Celery worker and beat containers
 for background tasks. Nginx listens on port `80` and forwards requests to the
 FastAPI backend running on `backend:8000`. The API is thus reachable on

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure script is executed from project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+# Create .env from example if it doesn't exist
+if [ ! -f .env ]; then
+    cp .env.example .env
+    echo "Created .env from .env.example"
+fi
+
+# Build and start containers
+docker-compose up --build -d
+
+# Display URLs
+echo "Services are starting..."
+echo "API: http://localhost"
+echo "Frontend: http://localhost:3000"


### PR DESCRIPTION
## Summary
- add `quickstart.sh` script to spin up containers
- document new script in README

## Testing
- `pip install -r requirements.txt pytest`
- `pytest -q` *(fails: Settings ValidationError)*

------
https://chatgpt.com/codex/tasks/task_e_6842aa4a56b083319768f1217c2e3d50