### PR TITLE
Load SECRET_KEY from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@ POSTGRES_DB=stockdb
 # For production you might set DATABASE_URL to the PostgreSQL instance
 # DATABASE_URL=postgresql://stock:stock@db:5432/stockdb
 
-SECRET_KEY=changeme
+# Secret key used for signing JWT tokens. Replace with a random string
+SECRET_KEY=
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=admin
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ below a configured threshold, a warning is displayed during the status check.
 
 1. Copy `.env.example` to `.env` and adjust values. At a minimum set
    `SECRET_KEY`. `DATABASE_URL` defaults to SQLite but can be overridden.
+   When running with `docker-compose` the backend container reads
+   `SECRET_KEY` from this file.
    Optional settings include `ADMIN_USERNAME`, `ADMIN_PASSWORD`,
    `NEXT_PUBLIC_API_URL` for the frontend and background worker variables
    such as `CELERY_BROKER_URL`, `STOCK_CHECK_INTERVAL`, `SLACK_WEBHOOK_URL`,
@@ -214,11 +216,11 @@ docker build -t stock-saas-backend .
 docker run -e SECRET_KEY=mysecret -p 8000:8000 stock-saas-backend
 ```
 
-To start the backend together with a PostgreSQL database, Nginx reverse proxy and the Next.js frontend use `docker-compose`:
+To start the backend together with a PostgreSQL database, Nginx reverse proxy and the Next.js frontend use `docker-compose`. The compose file loads environment variables from `.env`, so ensure `SECRET_KEY` is set there:
 
 ```bash
 cp .env.example .env
-# edit values as needed
+# edit values as needed; docker-compose reads variables from this file
 docker-compose up --build
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build: .
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-stock}:${POSTGRES_PASSWORD:-stock}@db:5432/${POSTGRES_DB:-stockdb}
-      SECRET_KEY: changeme
+      SECRET_KEY: ${SECRET_KEY}
       ADMIN_USERNAME: admin
       ADMIN_PASSWORD: admin
     depends_on:


### PR DESCRIPTION
## Summary
- read `SECRET_KEY` from `.env` in docker-compose
- clarify `.env.example` with comment on `SECRET_KEY`
- document docker-compose variable usage in README

## Testing
- `pip install -q -r requirements.txt && pip install -q pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ac9ed4a08331b3cee78edc3e0e8f