### PR TITLE
Add Playwright install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,18 @@ After logging in you will see the dashboard listing all items. Links are provide
 
 Admins can also open `/users` to manage accounts. The page lists existing users and includes a form to create new ones.
 
+### Frontend tests
+
+Playwright powers browser tests located in `frontend/tests`. Before running
+`npx playwright test`, download the browser binaries:
+
+```bash
+cd frontend
+npx playwright install
+```
+
+You can also run `./scripts/install_browsers.sh` inside `frontend/` to automate
+this step.
 
 
 ## Running with Docker

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -12,4 +12,5 @@ This directory contains the Next.js interface managed by the **frontend-agent**.
 - Start the development server using `npm run dev`.
 - The API base URL defaults to `http://localhost:8000` but can be overridden via `NEXT_PUBLIC_API_URL`.
 - Keep components simple and avoid heavy UI frameworks.
+- Before running Playwright tests, execute `npx playwright install` to download the required browser binaries. A helper script is available at `scripts/install_browsers.sh`.
 

--- a/frontend/scripts/install_browsers.sh
+++ b/frontend/scripts/install_browsers.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+# Install Playwright browser binaries
+npx playwright install


### PR DESCRIPTION
## Summary
- document running `npx playwright install` before frontend tests
- add helper script `install_browsers.sh`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842b19c22208331971ef3a085476a0d