### PR TITLE
Fix TestClient for httpx transport deprecation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,13 @@ import tempfile
 import asyncio
 import pytest
 from fastapi.testclient import TestClient
+import httpx
+import inspect
+
+def _make_test_client(app):
+    if "transport" in inspect.signature(TestClient).parameters:
+        return TestClient(app, transport=httpx.WSGITransport(app))
+    return TestClient(app)
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
@@ -71,7 +78,7 @@ def client():
 
     main.app.dependency_overrides[database_async.get_async_db] = override_get_async_db
 
-    with TestClient(main.app) as c:
+    with _make_test_client(main.app) as c:
         if hasattr(main.app.state, "rate_limiter"):
             main.app.state.rate_limiter.attempts.clear()
         yield c


### PR DESCRIPTION
## Summary
- add `_make_test_client` helper that uses httpx.WSGITransport when supported
- use helper in tests to remove deprecated httpx usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b19d32d88331a9279e51d79d3e08