### PR TITLE
Add generic API helpers and stock types

### DIFF
--- a/frontend/components/RegisterForm.tsx
+++ b/frontend/components/RegisterForm.tsx
@@ -4,11 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { apiGet, apiPost, isAuthenticated } from '@/lib/api';
-
-interface Department {
-  id: number;
-  name: string;
-}
+import type { Department } from '@/types/stock';
 
 export default function RegisterForm() {
   const [email, setEmail] = useState('');

--- a/frontend/types/stock.ts
+++ b/frontend/types/stock.ts
@@ -23,11 +23,17 @@ export interface StockItem {
 }
 
 export interface StockHistoryEntry {
-  id: number;
-  item_id: number;
-  change: number;
-  timestamp: string;
-  note?: string;
+  id: number
+  item_id: number
+  date: string
+  type: 'request' | 'add' | 'transfer' | 'issue' | 'delete'
+  quantity: number
+  previous_quantity: number
+  new_quantity: number
+  notes?: string
+  from_department_id?: number
+  to_department_id?: number
+  source?: string
 }
 
 export interface DepartmentStock {


### PR DESCRIPTION
## Summary
- extend `frontend/lib/api.ts` with typed helpers (`apiFetch`, `apiPost`, `apiGet`, `isAuthenticated`)
- centralize stock item types in `frontend/types/stock.ts`
- use shared `Department` type in `RegisterForm`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b6f8d60c8331bee5e5795cfefafe