### PR TITLE
Update Playwright tests for new dashboard

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "@radix-ui/react-toast": "latest",
     "@radix-ui/react-toggle": "latest",
     "@radix-ui/react-toggle-group": "latest",
-    "@radix-ui/react-tooltip": "latest"
+    "@radix-ui/react-tooltip": "latest",
 
     "clsx": "^2.1.0",
     "tailwind-merge": "^2.2.1"

--- a/frontend/tests/dashboard.spec.ts
+++ b/frontend/tests/dashboard.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from '@playwright/test';
 
-test('inventory dashboard has nav links', async ({ page }) => {
+test('stock dashboard shows departments', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByRole('heading', { name: 'Inventory Dashboard' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Add Item' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Issue Item' })).toBeVisible();
-  await expect(page.getByRole('link', { name: 'Return Item' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Systems Stock' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Systems' })).toBeVisible();
 });
 
 test('add item form fields present', async ({ page }) => {


### PR DESCRIPTION
## Summary
- update Playwright selector for dashboard page
- fix malformed `package.json`

## Testing
- `pytest -q`
- `npx playwright test` *(fails: RegisterForm compile error)*

------
https://chatgpt.com/codex/tasks/task_e_6842b6fd7c708331b6f761ac098de77c