### PR TITLE
Fix auth context typing

### DIFF
--- a/frontend/lib/auth-context.tsx
+++ b/frontend/lib/auth-context.tsx
@@ -3,18 +3,25 @@ import { login as apiLogin } from './api';
 
 interface AuthContextType {
   token: string | null;
+  /** Whether a token is currently stored */
+  isAuthenticated: boolean;
+  /** optional user object for role based checks */
+  user: any | null;
   login: (username: string, password: string) => Promise<void>;
   logout: () => void;
 }
 
 const AuthContext = createContext<AuthContextType>({
   token: null,
+  isAuthenticated: false,
+  user: null,
   login: async () => {},
   logout: () => {},
 });
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [token, setToken] = useState<string | null>(null);
+  const [user, setUser] = useState<any | null>(null);
 
   useEffect(() => {
     const stored = localStorage.getItem('token');
@@ -32,10 +39,13 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const logout = () => {
     localStorage.removeItem('token');
     setToken(null);
+    setUser(null);
   };
 
+  const isAuthenticated = !!token;
+
   return (
-    <AuthContext.Provider value={{ token, login, logout }}>
+    <AuthContext.Provider value={{ token, isAuthenticated, user, login, logout }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- update AuthContextType and provider to expose `isAuthenticated` and `user`

## Testing
- `pytest -q`
- `npm ci` *(installs frontend deps)*
- `npx tsc -p tsconfig.json` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6842bce448248331b85d33a31ba44c29