### PR TITLE
Update frontend agent notes

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -13,4 +13,5 @@ This directory contains the Next.js interface managed by the **frontend-agent**.
 - The API base URL defaults to `http://localhost:8000` but can be overridden via `NEXT_PUBLIC_API_URL`.
 - Keep components simple and avoid heavy UI frameworks.
 - Before running Playwright tests, execute `npx playwright install` to download the required browser binaries. A helper script is available at `scripts/install_browsers.sh`.
+- Run browser tests using `npx playwright test`.
 


### PR DESCRIPTION
## Summary
- note how to run the Playwright tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6842e422848883319a979223eb040559