### PR TITLE
Add ops-agent instructions

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,17 @@
+# ops-agent Instructions
+
+This file defines the **ops-agent** responsible for operational scripts and container configuration.
+
+## Scope
+
+These guidelines apply to the `scripts/` and `nginx/` directories.
+
+## Responsibilities
+- Build and maintain Docker images (`Dockerfile`).
+- Use `docker-compose` to orchestrate services defined in `docker-compose.yml`.
+- Manage the Nginx configuration at `nginx/default.conf`.
+- Rotate secrets using `scripts/rotate_secret.py`.
+
+## Quickstart
+
+Run `scripts/quickstart.sh` from the project root to build and launch all containers with `docker-compose`.


### PR DESCRIPTION
## Summary
- outline ops-agent responsibilities for Docker builds, docker-compose, Nginx configuration and secret rotation
- describe quickstart using `scripts/quickstart.sh`

## Testing
- `pip install -r requirements.txt` *(fails: cython_sources)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6842e4233cd08331908e6e7e90d6b795