### PR TITLE
Add Alembic instructions

### DIFF
--- a/alembic/AGENTS.md
+++ b/alembic/AGENTS.md
@@ -1,0 +1,20 @@
+# db-agent Instructions
+
+This folder contains Alembic migration scripts used to evolve the database schema.
+It is maintained by the **db-agent** (also referred to as the **backend-agent**).
+
+## Generating migrations
+- After changing SQLAlchemy models, create a new revision with
+  ```bash
+  alembic revision --autogenerate -m "describe change"
+  ```
+  This command inspects the models and database to produce a migration file
+  under `alembic/versions`.
+
+## Applying migrations
+- Apply all outstanding migrations to the configured database using
+  ```bash
+  alembic upgrade head
+  ```
+  Run this whenever the application starts on a new environment or when
+  deploying updates.


### PR DESCRIPTION
## Summary
- document migrations workflow for db-agent under `alembic/`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi.testclient' / pydantic schema errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842e42567188331836476e70191e67a