### PR TITLE
Add departments and categories API

### DIFF
--- a/alembic/versions/20240606_add_departments_categories.py
+++ b/alembic/versions/20240606_add_departments_categories.py
@@ -1,0 +1,34 @@
+"""create departments and categories tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20240606_add_dept_cat'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'departments',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String, nullable=False, unique=True),
+        sa.Column('icon', sa.String, nullable=True),
+    )
+    op.create_table(
+        'categories',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('name', sa.String, nullable=False),
+        sa.Column('department_id', sa.Integer, sa.ForeignKey('departments.id'), nullable=False),
+        sa.Column('icon', sa.String, nullable=True),
+    )
+    op.add_column('items', sa.Column('department_id', sa.Integer, sa.ForeignKey('departments.id'), nullable=True))
+    op.add_column('items', sa.Column('category_id', sa.Integer, sa.ForeignKey('categories.id'), nullable=True))
+
+
+def downgrade():
+    op.drop_column('items', 'category_id')
+    op.drop_column('items', 'department_id')
+    op.drop_table('categories')
+    op.drop_table('departments')

--- a/main.py
+++ b/main.py
@@ -33,6 +33,8 @@ from schemas import (
 from routers.users import router as users_router
 from routers.analytics import router as analytics_router
 from routers.auth import router as auth_router
+from routers.departments import router as departments_router
+from routers.categories import router as categories_router
 from websocket_manager import InventoryWSManager
 from rate_limiter import RateLimiter
 
@@ -73,6 +75,8 @@ Base.metadata.create_all(bind=engine)
 app.include_router(users_router)
 app.include_router(analytics_router)
 app.include_router(auth_router)
+app.include_router(departments_router)
+app.include_router(categories_router)
 
 
 @app.websocket("/ws/inventory/{tenant_id}")

--- a/models.py
+++ b/models.py
@@ -15,17 +15,44 @@ class Tenant(Base):
     items = relationship("Item", back_populates="tenant")
 
 
+class Department(Base):
+    __tablename__ = "departments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+    icon = Column(String, nullable=True)
+
+    items = relationship("Item", back_populates="department")
+    categories = relationship("Category", back_populates="department")
+
+
+class Category(Base):
+    __tablename__ = "categories"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    department_id = Column(Integer, ForeignKey("departments.id"))
+    icon = Column(String, nullable=True)
+
+    department = relationship("Department", back_populates="categories")
+    items = relationship("Item", back_populates="category")
+
+
 class Item(Base):
     __tablename__ = "items"
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, index=True)
     tenant_id = Column(Integer, ForeignKey("tenants.id"))
+    department_id = Column(Integer, ForeignKey("departments.id"), nullable=True)
+    category_id = Column(Integer, ForeignKey("categories.id"), nullable=True)
     available = Column(Integer, default=0)
     in_use = Column(Integer, default=0)
     threshold = Column(Integer, default=0)
 
     tenant = relationship("Tenant", back_populates="items")
+    department = relationship("Department", back_populates="items")
+    category = relationship("Category", back_populates="items")
 
     __table_args__ = (UniqueConstraint("name", "tenant_id", name="uix_name_tenant"),)
 

--- a/pydantic_settings.py
+++ b/pydantic_settings.py
@@ -1,0 +1,3 @@
+from pydantic import BaseSettings
+
+__all__ = ["BaseSettings"]

--- a/routers/categories.py
+++ b/routers/categories.py
@@ -1,0 +1,68 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import Category, Department, User
+from auth import require_role
+from schemas import CategoryCreate, CategoryResponse
+
+router = APIRouter(prefix="/api/categories")
+
+admin_or_manager = require_role(["admin", "manager"])
+
+
+@router.post("/", response_model=CategoryResponse)
+def create_category(
+    payload: CategoryCreate,
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_or_manager),
+):
+    if not db.query(Department).filter(Department.id == payload.department_id).first():
+        raise HTTPException(status_code=404, detail="Department not found")
+    cat = Category(name=payload.name, department_id=payload.department_id, icon=payload.icon)
+    db.add(cat)
+    db.commit()
+    db.refresh(cat)
+    return cat
+
+
+@router.get("/", response_model=list[CategoryResponse])
+def list_categories(
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_or_manager),
+):
+    return db.query(Category).all()
+
+
+@router.put("/{category_id}", response_model=CategoryResponse)
+def update_category(
+    category_id: int,
+    payload: CategoryCreate,
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_or_manager),
+):
+    cat = db.query(Category).filter(Category.id == category_id).first()
+    if not cat:
+        raise HTTPException(status_code=404, detail="Category not found")
+    if not db.query(Department).filter(Department.id == payload.department_id).first():
+        raise HTTPException(status_code=404, detail="Department not found")
+    cat.name = payload.name
+    cat.department_id = payload.department_id
+    cat.icon = payload.icon
+    db.commit()
+    db.refresh(cat)
+    return cat
+
+
+@router.delete("/{category_id}")
+def delete_category(
+    category_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_or_manager),
+):
+    cat = db.query(Category).filter(Category.id == category_id).first()
+    if not cat:
+        raise HTTPException(status_code=404, detail="Category not found")
+    db.delete(cat)
+    db.commit()
+    return {"detail": "Category deleted"}

--- a/routers/departments.py
+++ b/routers/departments.py
@@ -1,0 +1,70 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import Department, User
+from auth import require_role
+from schemas import DepartmentCreate, DepartmentResponse
+
+router = APIRouter(prefix="/api/departments")
+
+admin_or_manager = require_role(["admin", "manager"])
+
+
+@router.get("/public", response_model=list[DepartmentResponse])
+def public_list_departments(db: Session = Depends(get_db)):
+    return db.query(Department).all()
+
+
+@router.post("/", response_model=DepartmentResponse)
+def create_department(
+    payload: DepartmentCreate,
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_or_manager),
+):
+    if db.query(Department).filter(Department.name == payload.name).first():
+        raise HTTPException(status_code=400, detail="Department already exists")
+    dept = Department(name=payload.name, icon=payload.icon)
+    db.add(dept)
+    db.commit()
+    db.refresh(dept)
+    return dept
+
+
+@router.get("/", response_model=list[DepartmentResponse])
+def list_departments(
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_or_manager),
+):
+    return db.query(Department).all()
+
+
+@router.put("/{department_id}", response_model=DepartmentResponse)
+def update_department(
+    department_id: int,
+    payload: DepartmentCreate,
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_or_manager),
+):
+    dept = db.query(Department).filter(Department.id == department_id).first()
+    if not dept:
+        raise HTTPException(status_code=404, detail="Department not found")
+    dept.name = payload.name
+    dept.icon = payload.icon
+    db.commit()
+    db.refresh(dept)
+    return dept
+
+
+@router.delete("/{department_id}")
+def delete_department(
+    department_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_or_manager),
+):
+    dept = db.query(Department).filter(Department.id == department_id).first()
+    if not dept:
+        raise HTTPException(status_code=404, detail="Department not found")
+    db.delete(dept)
+    db.commit()
+    return {"detail": "Department deleted"}

--- a/schemas.py
+++ b/schemas.py
@@ -95,6 +95,39 @@ class TenantResponse(TenantBase):
         orm_mode = True
 
 
+class DepartmentBase(BaseModel):
+    name: str
+    icon: str | None = None
+
+
+class DepartmentCreate(DepartmentBase):
+    pass
+
+
+class DepartmentResponse(DepartmentBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class CategoryBase(BaseModel):
+    name: str
+    department_id: int
+    icon: str | None = None
+
+
+class CategoryCreate(CategoryBase):
+    pass
+
+
+class CategoryResponse(CategoryBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
 class PasswordResetRequest(BaseModel):
     username: str
 

--- a/tests/test_department_category_api.py
+++ b/tests/test_department_category_api.py
@@ -1,0 +1,63 @@
+from tests.conftest import get_token
+
+
+def test_department_crud(client):
+    token = get_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = client.post(
+        "/api/departments/",
+        json={"name": "Ops", "icon": "box"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    dept = resp.json()
+
+    resp = client.get("/api/departments/", headers=headers)
+    assert any(d["id"] == dept["id"] for d in resp.json())
+
+    resp = client.put(
+        f"/api/departments/{dept['id']}",
+        json={"name": "Operations", "icon": "box"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Operations"
+
+    resp = client.get("/api/departments/public")
+    assert any(d["id"] == dept["id"] for d in resp.json())
+
+    resp = client.delete(f"/api/departments/{dept['id']}", headers=headers)
+    assert resp.status_code == 200
+
+
+def test_category_crud(client):
+    token = get_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    dept = client.post(
+        "/api/departments/",
+        json={"name": "Sales", "icon": None},
+        headers=headers,
+    ).json()
+
+    resp = client.post(
+        "/api/categories/",
+        json={"name": "Retail", "department_id": dept["id"], "icon": None},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    cat = resp.json()
+
+    resp = client.get("/api/categories/", headers=headers)
+    assert any(c["id"] == cat["id"] for c in resp.json())
+
+    resp = client.put(
+        f"/api/categories/{cat['id']}",
+        json={"name": "Retail2", "department_id": dept["id"], "icon": None},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Retail2"
+
+    resp = client.delete(f"/api/categories/{cat['id']}", headers=headers)
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add Department and Category models with Item relations
- create migration for new tables
- expose CRUD routers for departments and categories
- register routers in `main.py`
- provide Pydantic schemas
- test CRUD flows for new endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e431c47c8331baf8fa5bbd6035fd