### PR TITLE
Add inventory item fields

### DIFF
--- a/alembic/versions/0001_add_item_extra_fields.py
+++ b/alembic/versions/0001_add_item_extra_fields.py
@@ -1,0 +1,26 @@
+"""add item extra fields"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('items', sa.Column('min_par', sa.Integer(), server_default='0'))
+    op.add_column('items', sa.Column('department_id', sa.Integer(), nullable=True))
+    op.add_column('items', sa.Column('category_id', sa.Integer(), nullable=True))
+    op.add_column('items', sa.Column('stock_code', sa.String(), nullable=True))
+    op.add_column('items', sa.Column('status', sa.String(), nullable=True))
+    op.alter_column('items', 'min_par', server_default=None)
+
+
+def downgrade():
+    op.drop_column('items', 'status')
+    op.drop_column('items', 'stock_code')
+    op.drop_column('items', 'category_id')
+    op.drop_column('items', 'department_id')
+    op.drop_column('items', 'min_par')

--- a/config.py
+++ b/config.py
@@ -1,12 +1,21 @@
 from functools import lru_cache
-from pydantic_settings import BaseSettings
-from pydantic import Field, ConfigDict
+try:
+    from pydantic_settings import BaseSettings  # type: ignore
+    from pydantic import Field, ConfigDict
+except Exception:  # fallback for pydantic v1
+    from pydantic import BaseSettings, Field
+    ConfigDict = None
 
 from secrets_manager import get_manager
 
 
 class Settings(BaseSettings):
-    model_config = ConfigDict(extra="ignore", env_file=".env")
+    if ConfigDict is not None:
+        model_config = ConfigDict(extra="ignore", env_file=".env")
+    else:
+        class Config:
+            extra = "ignore"
+            env_file = ".env"
     database_url: str = Field("sqlite:///./inventory.db", env="DATABASE_URL")
     secret_key: str | None = Field(None, env="SECRET_KEY")
     secret_store_file: str | None = Field(None, env="SECRET_STORE_FILE")

--- a/inventory_core.py
+++ b/inventory_core.py
@@ -38,6 +38,11 @@ def add_item(
     qty: int,
     threshold: int,
     tenant_id: int,
+    min_par: int = 0,
+    department_id: Optional[int] = None,
+    category_id: Optional[int] = None,
+    stock_code: Optional[str] = None,
+    status: Optional[str] = None,
     user_id: Optional[int] = None,
 ) -> Item:
     if qty <= 0:
@@ -52,12 +57,27 @@ def add_item(
             available=0,
             in_use=0,
             threshold=threshold,
+            min_par=min_par,
+            department_id=department_id,
+            category_id=category_id,
+            stock_code=stock_code,
+            status=status,
         )
         db.add(item)
 
     item.available += qty
     if threshold is not None:
         item.threshold = threshold
+    if min_par is not None:
+        item.min_par = min_par
+    if department_id is not None:
+        item.department_id = department_id
+    if category_id is not None:
+        item.category_id = category_id
+    if stock_code is not None:
+        item.stock_code = stock_code
+    if status is not None:
+        item.status = status
 
     db.flush()
     _log_action(db, user_id, item, "add", qty)
@@ -123,6 +143,11 @@ def get_status(
                 "available": item.available,
                 "in_use": item.in_use,
                 "threshold": item.threshold,
+                "min_par": item.min_par,
+                "department_id": item.department_id,
+                "category_id": item.category_id,
+                "stock_code": item.stock_code,
+                "status": item.status,
             }
     else:
         for item in base_query.all():
@@ -130,6 +155,11 @@ def get_status(
                 "available": item.available,
                 "in_use": item.in_use,
                 "threshold": item.threshold,
+                "min_par": item.min_par,
+                "department_id": item.department_id,
+                "category_id": item.category_id,
+                "stock_code": item.stock_code,
+                "status": item.status,
             }
 
     return items
@@ -151,6 +181,11 @@ def update_item(
     tenant_id: int,
     new_name: Optional[str] = None,
     threshold: Optional[int] = None,
+    min_par: Optional[int] = None,
+    department_id: Optional[int] = None,
+    category_id: Optional[int] = None,
+    stock_code: Optional[str] = None,
+    status: Optional[str] = None,
     user_id: Optional[int] = None,
 ) -> Item:
     """Update an item's name and/or threshold."""
@@ -164,6 +199,66 @@ def update_item(
         if threshold < 0:
             raise ValueError("Threshold cannot be negative")
         item.threshold = threshold
+    if min_par is not None:
+        if min_par < 0:
+            raise ValueError("min_par cannot be negative")
+        item.min_par = min_par
+    if department_id is not None:
+        item.department_id = department_id
+    if category_id is not None:
+        item.category_id = category_id
+    if stock_code is not None:
+        item.stock_code = stock_code
+    if status is not None:
+        item.status = status
+    if min_par is not None:
+        if min_par < 0:
+            raise ValueError("min_par cannot be negative")
+        item.min_par = min_par
+    if department_id is not None:
+        item.department_id = department_id
+    if category_id is not None:
+        item.category_id = category_id
+    if stock_code is not None:
+        item.stock_code = stock_code
+    if status is not None:
+        item.status = status
+    if min_par is not None:
+        if min_par < 0:
+            raise ValueError("min_par cannot be negative")
+        item.min_par = min_par
+    if department_id is not None:
+        item.department_id = department_id
+    if category_id is not None:
+        item.category_id = category_id
+    if stock_code is not None:
+        item.stock_code = stock_code
+    if status is not None:
+        item.status = status
+    if min_par is not None:
+        if min_par < 0:
+            raise ValueError("min_par cannot be negative")
+        item.min_par = min_par
+    if department_id is not None:
+        item.department_id = department_id
+    if category_id is not None:
+        item.category_id = category_id
+    if stock_code is not None:
+        item.stock_code = stock_code
+    if status is not None:
+        item.status = status
+    if min_par is not None:
+        if min_par < 0:
+            raise ValueError("min_par cannot be negative")
+        item.min_par = min_par
+    if department_id is not None:
+        item.department_id = department_id
+    if category_id is not None:
+        item.category_id = category_id
+    if stock_code is not None:
+        item.stock_code = stock_code
+    if status is not None:
+        item.status = status
 
     _log_action(db, user_id, item, "update", 0)
     db.commit()
@@ -193,6 +288,11 @@ async def async_add_item(
     qty: int,
     threshold: int,
     tenant_id: int,
+    min_par: int = 0,
+    department_id: Optional[int] = None,
+    category_id: Optional[int] = None,
+    stock_code: Optional[str] = None,
+    status: Optional[str] = None,
     user_id: Optional[int] = None,
 ) -> Item:
     if qty <= 0:
@@ -210,12 +310,27 @@ async def async_add_item(
             available=0,
             in_use=0,
             threshold=threshold,
+            min_par=min_par,
+            department_id=department_id,
+            category_id=category_id,
+            stock_code=stock_code,
+            status=status,
         )
         db.add(item)
 
     item.available += qty
     if threshold is not None:
         item.threshold = threshold
+    if min_par is not None:
+        item.min_par = min_par
+    if department_id is not None:
+        item.department_id = department_id
+    if category_id is not None:
+        item.category_id = category_id
+    if stock_code is not None:
+        item.stock_code = stock_code
+    if status is not None:
+        item.status = status
 
     await db.flush()
     await _async_log_action(db, user_id, item, "add", qty)
@@ -288,6 +403,11 @@ async def async_get_status(
                 "available": item.available,
                 "in_use": item.in_use,
                 "threshold": item.threshold,
+                "min_par": item.min_par,
+                "department_id": item.department_id,
+                "category_id": item.category_id,
+                "stock_code": item.stock_code,
+                "status": item.status,
             }
     else:
         result = await db.execute(stmt)
@@ -296,6 +416,11 @@ async def async_get_status(
                 "available": item.available,
                 "in_use": item.in_use,
                 "threshold": item.threshold,
+                "min_par": item.min_par,
+                "department_id": item.department_id,
+                "category_id": item.category_id,
+                "stock_code": item.stock_code,
+                "status": item.status,
             }
 
     return items
@@ -318,6 +443,11 @@ async def async_update_item(
     tenant_id: int,
     new_name: Optional[str] = None,
     threshold: Optional[int] = None,
+    min_par: Optional[int] = None,
+    department_id: Optional[int] = None,
+    category_id: Optional[int] = None,
+    stock_code: Optional[str] = None,
+    status: Optional[str] = None,
     user_id: Optional[int] = None,
 ) -> Item:
     result = await db.execute(
@@ -333,6 +463,18 @@ async def async_update_item(
         if threshold < 0:
             raise ValueError("Threshold cannot be negative")
         item.threshold = threshold
+    if min_par is not None:
+        if min_par < 0:
+            raise ValueError("min_par cannot be negative")
+        item.min_par = min_par
+    if department_id is not None:
+        item.department_id = department_id
+    if category_id is not None:
+        item.category_id = category_id
+    if stock_code is not None:
+        item.stock_code = stock_code
+    if status is not None:
+        item.status = status
 
     await _async_log_action(db, user_id, item, "update", 0)
     await db.commit()

--- a/main.py
+++ b/main.py
@@ -143,6 +143,11 @@ async def api_add_item(
         payload.quantity,
         payload.threshold,
         payload.tenant_id,
+        payload.min_par,
+        payload.department_id,
+        payload.category_id,
+        payload.stock_code,
+        payload.status,
         user_id=user.id,
     )
     asyncio.create_task(
@@ -301,6 +306,11 @@ async def api_update_item(
             tenant_id=payload.tenant_id,
             new_name=payload.new_name,
             threshold=payload.threshold,
+            min_par=payload.min_par,
+            department_id=payload.department_id,
+            category_id=payload.category_id,
+            stock_code=payload.stock_code,
+            status=payload.status,
             user_id=user.id,
         )
         asyncio.create_task(

--- a/models.py
+++ b/models.py
@@ -24,6 +24,11 @@ class Item(Base):
     available = Column(Integer, default=0)
     in_use = Column(Integer, default=0)
     threshold = Column(Integer, default=0)
+    min_par = Column(Integer, default=0)
+    department_id = Column(Integer, nullable=True)
+    category_id = Column(Integer, nullable=True)
+    stock_code = Column(String, nullable=True)
+    status = Column(String, nullable=True)
 
     tenant = relationship("Tenant", back_populates="items")
 

--- a/schemas.py
+++ b/schemas.py
@@ -7,6 +7,11 @@ class ItemBase(BaseModel):
     available: int
     in_use: int
     threshold: int
+    min_par: int
+    department_id: int | None = None
+    category_id: int | None = None
+    stock_code: str | None = None
+    status: str | None = None
 
 
 class ItemCreate(BaseModel):
@@ -14,6 +19,11 @@ class ItemCreate(BaseModel):
     quantity: conint(gt=0)
     threshold: conint(ge=0) = 0
     tenant_id: int
+    min_par: conint(ge=0) = 0
+    department_id: int | None = None
+    category_id: int | None = None
+    stock_code: str | None = None
+    status: str | None = None
 
 
 class ItemUpdate(BaseModel):
@@ -21,6 +31,11 @@ class ItemUpdate(BaseModel):
     tenant_id: int
     new_name: str | None = None
     threshold: conint(ge=0) | None = None
+    min_par: conint(ge=0) | None = None
+    department_id: int | None = None
+    category_id: int | None = None
+    stock_code: str | None = None
+    status: str | None = None
 
 
 class ItemDelete(BaseModel):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -40,6 +40,11 @@ class ItemFactory(BaseFactory):
     available = 0
     in_use = 0
     threshold = 0
+    min_par = 0
+    department_id = None
+    category_id = None
+    stock_code = None
+    status = None
 
 
 class AuditLogFactory(BaseFactory):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,13 +31,25 @@ def test_multi_tenant_isolation(client):
 
     client.post(
         "/items/add",
-        json={"name": "widget", "quantity": 2, "threshold": 0, "tenant_id": 1},
+        json={
+            "name": "widget",
+            "quantity": 2,
+            "threshold": 0,
+            "min_par": 0,
+            "tenant_id": 1,
+        },
         headers=h1,
     )
 
     client.post(
         "/items/add",
-        json={"name": "widget", "quantity": 5, "threshold": 0, "tenant_id": tenant2.id},
+        json={
+            "name": "widget",
+            "quantity": 5,
+            "threshold": 0,
+            "min_par": 0,
+            "tenant_id": tenant2.id,
+        },
         headers=h2,
     )
 

--- a/tests/test_inventory_core.py
+++ b/tests/test_inventory_core.py
@@ -32,7 +32,23 @@ def db():
 
 def test_add_issue_return(db):
     session, tenant_id = db
-    item = add_item(session, "widget", 5, threshold=2, tenant_id=tenant_id)
+    item = add_item(
+        session,
+        "widget",
+        5,
+        threshold=2,
+        min_par=3,
+        department_id=1,
+        category_id=2,
+        stock_code="ABC",
+        status="active",
+        tenant_id=tenant_id,
+    )
+    assert item.min_par == 3
+    assert item.department_id == 1
+    assert item.category_id == 2
+    assert item.stock_code == "ABC"
+    assert item.status == "active"
     assert item.available == 5
     assert item.in_use == 0
 
@@ -70,10 +86,24 @@ def test_update_and_delete(db):
     session, tenant_id = db
     add_item(session, "phone", 2, threshold=1, tenant_id=tenant_id)
     item = update_item(
-        session, "phone", tenant_id=tenant_id, new_name="smartphone", threshold=5
+        session,
+        "phone",
+        tenant_id=tenant_id,
+        new_name="smartphone",
+        threshold=5,
+        min_par=4,
+        department_id=2,
+        category_id=3,
+        stock_code="XYZ",
+        status="inactive",
     )
     assert item.name == "smartphone"
     assert item.threshold == 5
+    assert item.min_par == 4
+    assert item.department_id == 2
+    assert item.category_id == 3
+    assert item.stock_code == "XYZ"
+    assert item.status == "inactive"
 
     delete_item(session, "smartphone", tenant_id=tenant_id)
     status = get_status(session, tenant_id=tenant_id, name="smartphone")

--- a/tests/test_inventory_core_async.py
+++ b/tests/test_inventory_core_async.py
@@ -29,7 +29,23 @@ async def adb():
 @pytest.mark.asyncio
 async def test_async_add_issue_return(adb):
     session, tenant_id = adb
-    item = await async_add_item(session, "widget", 5, threshold=2, tenant_id=tenant_id)
+    item = await async_add_item(
+        session,
+        "widget",
+        5,
+        threshold=2,
+        min_par=3,
+        department_id=1,
+        category_id=2,
+        stock_code="ABC",
+        status="active",
+        tenant_id=tenant_id,
+    )
+    assert item.min_par == 3
+    assert item.department_id == 1
+    assert item.category_id == 2
+    assert item.stock_code == "ABC"
+    assert item.status == "active"
     assert item.available == 5
     item = await async_issue_item(session, "widget", 3, tenant_id=tenant_id)
     assert item.available == 2
@@ -43,10 +59,24 @@ async def test_async_update_and_delete(adb):
     session, tenant_id = adb
     await async_add_item(session, "phone", 2, threshold=1, tenant_id=tenant_id)
     item = await async_update_item(
-        session, "phone", tenant_id, new_name="smartphone", threshold=5
+        session,
+        "phone",
+        tenant_id,
+        new_name="smartphone",
+        threshold=5,
+        min_par=4,
+        department_id=2,
+        category_id=3,
+        stock_code="XYZ",
+        status="inactive",
     )
     assert item.name == "smartphone"
     assert item.threshold == 5
+    assert item.min_par == 4
+    assert item.department_id == 2
+    assert item.category_id == 3
+    assert item.stock_code == "XYZ"
+    assert item.status == "inactive"
     await async_delete_item(session, "smartphone", tenant_id)
     status = await async_get_status(session, tenant_id, name="smartphone")
     assert status == {}

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -17,7 +17,13 @@ def setup_db():
 
 def test_notification_logs_created():
     db = setup_db()
-    item = Item(name="paper", available=0, in_use=0, threshold=1)
+    item = Item(
+        name="paper",
+        available=0,
+        in_use=0,
+        threshold=1,
+        min_par=0,
+    )
     db.add(item)
     db.commit()
 
@@ -65,7 +71,7 @@ def test_notification_logs_created():
 
 def test_no_notifications_when_stock_ok():
     db = setup_db()
-    item = Item(name="stapler", available=5, in_use=0, threshold=2)
+    item = Item(name="stapler", available=5, in_use=0, threshold=2, min_par=0)
     db.add(item)
     db.commit()
 
@@ -81,7 +87,14 @@ def test_no_notifications_when_stock_ok():
 
 def test_websocket_broadcast_on_low_stock():
     db = setup_db()
-    item = Item(name="ws", available=0, in_use=0, threshold=1, tenant_id=1)
+    item = Item(
+        name="ws",
+        available=0,
+        in_use=0,
+        threshold=1,
+        min_par=0,
+        tenant_id=1,
+    )
     db.add(item)
     db.commit()
 

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -113,7 +113,13 @@ def test_websocket_receives_inventory_updates(client):
     with client.websocket_connect("/ws/inventory/1") as ws:
         resp = client.post(
             "/items/add",
-            json={"name": "ws-item", "quantity": 1, "threshold": 0, "tenant_id": 1},
+            json={
+                "name": "ws-item",
+                "quantity": 1,
+                "threshold": 0,
+                "min_par": 0,
+                "tenant_id": 1,
+            },
             headers=headers,
         )
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- extend inventory `Item` model with department/category fields and metadata
- support new attributes in schemas and core logic
- migrate database columns with alembic
- expose the new fields through existing API routes
- update tests for new schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e4335acc8331bdfce67c561ccdc5