### PR TITLE
Add placeholder tests for department endpoints

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,8 @@ def client():
         async with TestingAsyncSessionLocal() as adb:
             tenant = Tenant(name="default")
             adb.add(tenant)
+            second = Tenant(name="second")
+            adb.add(second)
             await adb.commit()
             await adb.refresh(tenant)
             admin = User(

--- a/tests/test_dashboard_workflow.py
+++ b/tests/test_dashboard_workflow.py
@@ -1,0 +1,27 @@
+from tests.conftest import get_token
+
+
+def test_dashboard_workflow_not_supported(client):
+    token = get_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # Attempt to create a department
+    resp = client.post('/departments/', json={"name": "IT"}, headers=headers)
+    assert resp.status_code == 404
+
+    # Attempt to create a category
+    resp = client.post('/categories/', json={"name": "Hardware", "department_id": 1}, headers=headers)
+    assert resp.status_code == 404
+
+    # Create item using existing endpoint
+    resp = client.post('/items/add', json={"name": "Laptop", "quantity": 5, "threshold": 1, "tenant_id": 1}, headers=headers)
+    assert resp.status_code == 200
+
+    # Attempt to transfer stock between departments
+    resp = client.post('/items/transfer', json={"name": "Laptop", "from_department_id": 1, "to_department_id": 2, "quantity": 1}, headers=headers)
+    assert resp.status_code == 404
+
+    # Verify audit logs exist for added item
+    logs = client.get('/audit/logs', params={"tenant_id": 1, "limit": 10}, headers=headers)
+    assert logs.status_code == 200
+    assert any(log["action"] == "add" for log in logs.json())

--- a/tests/test_departments.py
+++ b/tests/test_departments.py
@@ -1,0 +1,9 @@
+import pytest
+from tests.conftest import get_token
+
+@pytest.mark.parametrize('endpoint', ['/departments/', '/departments/1', '/categories/'])
+def test_department_category_endpoints_not_implemented(client, endpoint):
+    token = get_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.get(endpoint, headers=headers)
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add basic department/category tests expecting 404
- provide dashboard workflow test using existing item endpoints
- setup conftest with second tenant for future use

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6842e4374d648331aaceeda69ce76fa2