### PR TITLE
Switch dashboard to API data

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,6 +3,14 @@ const path = require('path');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: '/items/status',
+        destination: '/api/items/status',
+      },
+    ];
+  },
   webpack(config) {
     config.resolve.alias['@'] = path.resolve(__dirname);
     return config;

--- a/frontend/pages/api/categories/[id].ts
+++ b/frontend/pages/api/categories/[id].ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { categories } from '../mock-data'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = parseInt(req.query.id as string)
+  const idx = categories.findIndex(c => c.id === id)
+  if (idx === -1) {
+    res.status(404).end()
+    return
+  }
+  if (req.method === 'PUT') {
+    const { name, department_id, icon } = req.body
+    categories[idx] = { ...categories[idx], name, department_id: Number(department_id), icon }
+    res.status(200).json(categories[idx])
+  } else if (req.method === 'DELETE') {
+    categories.splice(idx, 1)
+    res.status(200).json({ success: true })
+  } else {
+    res.status(405).end()
+  }
+}

--- a/frontend/pages/api/categories/index.ts
+++ b/frontend/pages/api/categories/index.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { categories } from '../mock-data'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    res.status(200).json(categories)
+  } else if (req.method === 'POST') {
+    const { name, department_id, icon } = req.body
+    const id = categories.length ? Math.max(...categories.map(c => c.id)) + 1 : 1
+    const cat = { id, name, department_id: Number(department_id), icon }
+    categories.push(cat)
+    res.status(200).json(cat)
+  } else {
+    res.status(405).end()
+  }
+}

--- a/frontend/pages/api/departments/[id].ts
+++ b/frontend/pages/api/departments/[id].ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { departments, categories } from '../mock-data'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const id = parseInt(req.query.id as string)
+  const idx = departments.findIndex(d => d.id === id)
+  if (idx === -1) {
+    res.status(404).end()
+    return
+  }
+
+  if (req.method === 'PUT') {
+    const { name, icon } = req.body
+    departments[idx] = { ...departments[idx], name, icon }
+    res.status(200).json(departments[idx])
+  } else if (req.method === 'DELETE') {
+    departments.splice(idx, 1)
+    for (let i = categories.length - 1; i >= 0; i--) {
+      if (categories[i].department_id === id) categories.splice(i, 1)
+    }
+    res.status(200).json({ success: true })
+  } else {
+    res.status(405).end()
+  }
+}

--- a/frontend/pages/api/departments/index.ts
+++ b/frontend/pages/api/departments/index.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { departments } from '../mock-data'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    res.status(200).json(departments)
+  } else if (req.method === 'POST') {
+    const { name, icon } = req.body
+    const id = departments.length ? Math.max(...departments.map(d => d.id)) + 1 : 1
+    const dept = { id, name, icon }
+    departments.push(dept)
+    res.status(200).json(dept)
+  } else {
+    res.status(405).end()
+  }
+}

--- a/frontend/pages/api/items/add.ts
+++ b/frontend/pages/api/items/add.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { items } from '../mock-data'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end()
+  const { name, quantity, min_par, category_id, department_id, stock_code, status } = req.body
+  const id = items.length ? Math.max(...items.map(i => i.id)) + 1 : 1
+  const item = { id, name, quantity: Number(quantity), min_par: Number(min_par), category_id: Number(category_id), department_id: Number(department_id), stock_code, status: status || 'available' }
+  items.push(item)
+  res.status(200).json(item)
+}

--- a/frontend/pages/api/items/delete.ts
+++ b/frontend/pages/api/items/delete.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { items } from '../mock-data'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'DELETE') return res.status(405).end()
+  const { id } = req.body
+  const idx = items.findIndex(i => i.id === Number(id))
+  if (idx === -1) return res.status(404).end()
+  items.splice(idx, 1)
+  res.status(200).json({ success: true })
+}

--- a/frontend/pages/api/items/status.ts
+++ b/frontend/pages/api/items/status.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { items } from '../mock-data'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    res.status(200).json(items)
+  } else {
+    res.status(405).end()
+  }
+}

--- a/frontend/pages/api/items/update.ts
+++ b/frontend/pages/api/items/update.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { items } from '../mock-data'
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'PUT') return res.status(405).end()
+  const { id, name, quantity, min_par, category_id, department_id, stock_code, status } = req.body
+  const idx = items.findIndex(i => i.id === Number(id))
+  if (idx === -1) return res.status(404).end()
+  items[idx] = { ...items[idx], name, quantity: Number(quantity), min_par: Number(min_par), category_id: Number(category_id), department_id: Number(department_id), stock_code, status }
+  res.status(200).json(items[idx])
+}

--- a/frontend/pages/api/mock-data.ts
+++ b/frontend/pages/api/mock-data.ts
@@ -1,0 +1,120 @@
+export interface Department {
+  id: number;
+  name: string;
+  icon?: string;
+}
+
+export interface Category {
+  id: number;
+  name: string;
+  department_id: number;
+  icon?: string;
+}
+
+export interface StockItem {
+  id: number;
+  name: string;
+  quantity: number;
+  min_par: number;
+  category_id: number;
+  department_id: number;
+  stock_code?: string;
+  status?: string;
+}
+
+export let departments: Department[] = [
+  { id: 1, name: "Systems", icon: "Computer" },
+  { id: 2, name: "Accounts/Warehouse", icon: "Briefcase" },
+  { id: 3, name: "Field Services", icon: "Truck" },
+];
+
+export let categories: Category[] = [
+  { id: 1, name: "Desktop Parts", department_id: 1 },
+  { id: 2, name: "Switches/Routers", department_id: 1 },
+  { id: 3, name: "Cables", department_id: 1 },
+  { id: 4, name: "Office Supplies", department_id: 2 },
+  { id: 5, name: "Tools", department_id: 3 },
+];
+
+export let items: StockItem[] = [
+  {
+    id: 1,
+    name: "Power Supply",
+    quantity: 5,
+    min_par: 2,
+    category_id: 1,
+    department_id: 1,
+    stock_code: "PS-001",
+    status: "available",
+  },
+  {
+    id: 2,
+    name: "RAM 8GB",
+    quantity: 7,
+    min_par: 3,
+    category_id: 1,
+    department_id: 1,
+    stock_code: "RAM-8G",
+    status: "available",
+  },
+  {
+    id: 3,
+    name: "SSD 500GB",
+    quantity: 0,
+    min_par: 5,
+    category_id: 1,
+    department_id: 1,
+    stock_code: "SSD-500",
+    status: "out",
+  },
+  {
+    id: 4,
+    name: "Network Switch 24-Port",
+    quantity: 2,
+    min_par: 1,
+    category_id: 2,
+    department_id: 1,
+    stock_code: "NSW-24",
+    status: "available",
+  },
+  {
+    id: 5,
+    name: "Router Wireless",
+    quantity: 3,
+    min_par: 2,
+    category_id: 2,
+    department_id: 1,
+    stock_code: "RW-001",
+    status: "available",
+  },
+  {
+    id: 6,
+    name: "Ethernet Cable 5m",
+    quantity: 12,
+    min_par: 10,
+    category_id: 3,
+    department_id: 1,
+    stock_code: "EC-5M",
+    status: "available",
+  },
+  {
+    id: 7,
+    name: "Stapler",
+    quantity: 4,
+    min_par: 5,
+    category_id: 4,
+    department_id: 2,
+    stock_code: "ST-001",
+    status: "low",
+  },
+  {
+    id: 8,
+    name: "Screwdriver Set",
+    quantity: 2,
+    min_par: 2,
+    category_id: 5,
+    department_id: 3,
+    stock_code: "SD-SET",
+    status: "available",
+  },
+];

--- a/frontend/tests/dashboard.spec.ts
+++ b/frontend/tests/dashboard.spec.ts
@@ -1,9 +1,11 @@
 import { test, expect } from '@playwright/test';
 
-test('stock dashboard shows departments', async ({ page }) => {
+test('stock dashboard shows departments and allows adding one', async ({ page }) => {
   await page.goto('/');
-  await expect(page.getByRole('heading', { name: 'Systems Stock' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Systems' })).toBeVisible();
+  await page.getByRole('button', { name: 'Add Department' }).click();
+  await page.getByPlaceholder('Department Name').fill('QA');
+  await page.getByRole('button', { name: 'Add' }).click();
+  await expect(page.getByRole('button', { name: 'QA' })).toBeVisible();
 });
 
 test('add item form fields present', async ({ page }) => {


### PR DESCRIPTION
## Summary
- fetch departments, categories and items from API
- persist edits by calling backend routes
- add mock API routes for Playwright
- update Next.js config with rewrite for items
- refine dashboard Playwright test

## Testing
- `CI=1 npx playwright test` *(fails: Timeout waiting for Add Department button)*
- `pytest -q` *(fails: ModuleNotFoundError for httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6842e436a99883318afd4018de7e6457