### PR TITLE
Fix nginx routing for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,10 @@ docker-compose up --build
 Alternatively run `./scripts/quickstart.sh` to start all services.
 
 The compose file also starts Redis along with Celery worker and beat containers
-for background tasks. Nginx listens on port `80` and forwards requests to the
-FastAPI backend running on `backend:8000`. The API is thus reachable on
-`http://localhost` while the frontend remains on `http://localhost:3000`.
+for background tasks. Nginx listens on port `80` and proxies `/api/` requests to
+the FastAPI container at `backend:8000` while all other paths are sent to the
+frontend at `frontend:3000`. You can therefore access the API on
+`http://localhost/api/` and the Next.js frontend on `http://localhost`.
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - postgres-data:/var/lib/postgresql/data
   backend:
     build: .
+    container_name: backend
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-stock}:${POSTGRES_PASSWORD:-stock}@db:5432/${POSTGRES_DB:-stockdb}
       SECRET_KEY: ${SECRET_KEY}
@@ -17,8 +18,8 @@ services:
       ADMIN_PASSWORD: admin
     depends_on:
       - db
-    ports:
-      - "8000:8000"
+    expose:
+      - "8000"
   redis:
     image: redis:7
   worker:
@@ -42,18 +43,20 @@ services:
   frontend:
     build:
       context: ./frontend/
+    container_name: frontend
     environment:
       NEXT_PUBLIC_API_URL: http://localhost:8000
     depends_on:
       - backend
-    ports:
-      - "3000:3000"
+    expose:
+      - "3000"
   nginx:
     image: nginx:1.25
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
       - backend
+      - frontend
     ports:
       - "80:80"
 volumes:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,8 +1,18 @@
 server {
     listen 80;
 
+    location /api/ {
+        proxy_pass http://backend:8000/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
-        proxy_pass http://backend:8000;
+        proxy_pass http://frontend:3000;
+        proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- route `/api/` to FastAPI container and `/` to frontend
- make backend and frontend discoverable by name in docker compose
- document new routing in README

## Testing
- `pytest -q tests/test_api.py::test_register_success` *(fails: NoForeignKeysError)*

------
https://chatgpt.com/codex/tasks/task_e_6842e9fd908083318b1ea5b427f0807f