### PR TITLE
Fix missing httpx for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ asyncpg
 python-jose[cryptography]
 passlib[bcrypt]
 python-multipart
-httpx==0.27.*
+httpx==0.27.2
 aiosqlite
 pytest-asyncio
 factory-boy


### PR DESCRIPTION
## Summary
- pin httpx in requirements.txt so tests have the proper dependency

## Testing
- `pytest -q` *(fails: PydanticImportError: `BaseSettings` has been moved to the `pydantic-settings` package)*

------
https://chatgpt.com/codex/tasks/task_e_6842ea21c86483318e50ec137e752ebc