### PR TITLE
Drop nginx from compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ docker build -t stock-saas-backend .
 docker run -e SECRET_KEY=mysecret -p 8000:8000 stock-saas-backend
 ```
 
-To start the backend together with a PostgreSQL database, Nginx reverse proxy and the Next.js frontend use `docker-compose`. The compose file loads environment variables from `.env`, so ensure `SECRET_KEY` is set there:
+To start the backend together with a PostgreSQL database and the Next.js frontend use `docker-compose`. The compose file loads environment variables from `.env`, so ensure `SECRET_KEY` is set there:
 
 ```bash
 cp .env.example .env
@@ -265,10 +265,8 @@ docker-compose up --build
 Alternatively run `./scripts/quickstart.sh` to start all services.
 
 The compose file also starts Redis along with Celery worker and beat containers
-for background tasks. Nginx listens on port `80` and proxies `/api/` requests to
-the FastAPI container at `backend:8000` while all other paths are sent to the
-frontend at `frontend:3000`. You can therefore access the API on
-`http://localhost/api/` and the Next.js frontend on `http://localhost`.
+for background tasks. The API is available on `http://localhost:8000` and the
+Next.js frontend on `http://localhost:3000` when the containers are running.
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       ADMIN_PASSWORD: admin
     depends_on:
       - db
-    expose:
-      - "8000"
+    ports:
+      - "8000:8000"
   redis:
     image: redis:7
   worker:
@@ -48,16 +48,7 @@ services:
       NEXT_PUBLIC_API_URL: http://localhost:8000
     depends_on:
       - backend
-    expose:
-      - "3000"
-  nginx:
-    image: nginx:1.25
-    volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
-    depends_on:
-      - backend
-      - frontend
     ports:
-      - "80:80"
+      - "3000:3000"
 volumes:
   postgres-data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ alembic
 python-dotenv
 pytest
 pydantic-settings
+PyYAML>=6.0.1

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -17,5 +17,5 @@ docker-compose up --build -d
 
 # Display URLs
 echo "Services are starting..."
-echo "API: http://localhost"
+echo "API: http://localhost:8000"
 echo "Frontend: http://localhost:3000"


### PR DESCRIPTION
## Summary
- expose backend and frontend directly in docker compose
- document direct service ports in README and quickstart script
- add PyYAML dependency for Python 3.11 wheels

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f07790588331867c00086cb6668a