### PR TITLE
Refactor async inventory functions to reuse sync logic

### DIFF
--- a/inventory_core.py
+++ b/inventory_core.py
@@ -1,6 +1,5 @@
 from typing import Dict, Optional, List, Tuple
 from sqlalchemy.orm import Session
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from models import Item, AuditLog
 from datetime import datetime
@@ -17,20 +16,6 @@ def _log_action(
         timestamp=datetime.utcnow(),
     )
     db.add(log)
-
-
-async def _async_log_action(
-    db: AsyncSession, user_id: Optional[int], item: Item, action: str, quantity: int
-):
-    log = AuditLog(
-        user_id=user_id,
-        item_id=item.id,
-        action=action,
-        quantity=quantity,
-        timestamp=datetime.utcnow(),
-    )
-    db.add(log)
-
 
 def add_item(
     db: Session,
@@ -356,48 +341,22 @@ async def async_add_item(
     status: Optional[str] = None,
     user_id: Optional[int] = None,
 ) -> Item:
-    if qty <= 0:
-        raise ValueError("Quantity must be positive")
-    if threshold < 0:
-        raise ValueError("Threshold cannot be negative")
-    result = await db.execute(
-        select(Item).where(Item.name == name, Item.tenant_id == tenant_id)
-    )
-    item = result.scalars().first()
-    if not item:
-        item = Item(
-            name=name,
-            tenant_id=tenant_id,
-            available=0,
-            in_use=0,
-            threshold=threshold,
-            min_par=min_par,
-            department_id=department_id,
-            category_id=category_id,
-            stock_code=stock_code,
-            status=status,
+    """Async wrapper around :func:`add_item`."""
+    return await db.run_sync(
+        lambda sync_db: add_item(
+            sync_db,
+            name,
+            qty,
+            threshold,
+            tenant_id,
+            min_par,
+            department_id,
+            category_id,
+            stock_code,
+            status,
+            user_id,
         )
-        db.add(item)
-
-    item.available += qty
-    if threshold is not None:
-        item.threshold = threshold
-    if min_par is not None:
-        item.min_par = min_par
-    if department_id is not None:
-        item.department_id = department_id
-    if category_id is not None:
-        item.category_id = category_id
-    if stock_code is not None:
-        item.stock_code = stock_code
-    if status is not None:
-        item.status = status
-
-    await db.flush()
-    await _async_log_action(db, user_id, item, "add", qty)
-    await db.commit()
-    await db.refresh(item)
-    return item
+    )
 
 
 async def async_issue_item(
@@ -407,22 +366,10 @@ async def async_issue_item(
     tenant_id: int,
     user_id: Optional[int] = None,
 ) -> Item:
-    if qty <= 0:
-        raise ValueError("Quantity must be positive")
-    result = await db.execute(
-        select(Item).where(Item.name == name, Item.tenant_id == tenant_id)
+    """Async wrapper around :func:`issue_item`."""
+    return await db.run_sync(
+        lambda sync_db: issue_item(sync_db, name, qty, tenant_id, user_id)
     )
-    item = result.scalars().first()
-    if not item or item.available < qty:
-        raise ValueError("Not enough stock to issue")
-
-    item.available -= qty
-    item.in_use += qty
-
-    await _async_log_action(db, user_id, item, "issue", qty)
-    await db.commit()
-    await db.refresh(item)
-    return item
 
 
 async def async_return_item(
@@ -432,88 +379,35 @@ async def async_return_item(
     tenant_id: int,
     user_id: Optional[int] = None,
 ) -> Item:
-    if qty <= 0:
-        raise ValueError("Quantity must be positive")
-    result = await db.execute(
-        select(Item).where(Item.name == name, Item.tenant_id == tenant_id)
+    """Async wrapper around :func:`return_item`."""
+    return await db.run_sync(
+        lambda sync_db: return_item(sync_db, name, qty, tenant_id, user_id)
     )
-    item = result.scalars().first()
-    if not item or item.in_use < qty:
-        raise ValueError("Invalid return quantity")
-
-    item.in_use -= qty
-    item.available += qty
-
-    await _async_log_action(db, user_id, item, "return", qty)
-    await db.commit()
-    await db.refresh(item)
-    return item
 
 
 async def async_get_status(
     db: AsyncSession, tenant_id: int, name: Optional[str] = None
 ) -> Dict[str, dict]:
-    items: Dict[str, dict] = {}
-    stmt = select(Item).where(Item.tenant_id == tenant_id)
-
-    if name:
-        result = await db.execute(stmt.where(Item.name == name))
-        item = result.scalars().first()
-        if item:
-            items[item.name] = {
-                "available": item.available,
-                "in_use": item.in_use,
-                "threshold": item.threshold,
-                "min_par": item.min_par,
-                "department_id": item.department_id,
-                "category_id": item.category_id,
-                "stock_code": item.stock_code,
-                "status": item.status,
-            }
-    else:
-        result = await db.execute(stmt)
-        for item in result.scalars().all():
-            items[item.name] = {
-                "available": item.available,
-                "in_use": item.in_use,
-                "threshold": item.threshold,
-                "min_par": item.min_par,
-                "department_id": item.department_id,
-                "category_id": item.category_id,
-                "stock_code": item.stock_code,
-                "status": item.status,
-            }
-
-    return items
+    """Async wrapper around :func:`get_status`."""
+    return await db.run_sync(lambda sync_db: get_status(sync_db, tenant_id, name))
 
 
 async def async_get_recent_logs(
     db: AsyncSession, limit: int = 10, tenant_id: Optional[int] = None
 ) -> List[AuditLog]:
-    stmt = select(AuditLog)
-    if tenant_id is not None:
-        stmt = stmt.join(Item).where(Item.tenant_id == tenant_id)
-
-    result = await db.execute(stmt.order_by(AuditLog.timestamp.desc()).limit(limit))
-    return result.scalars().all()
+    """Async wrapper around :func:`get_recent_logs`."""
+    return await db.run_sync(
+        lambda sync_db: get_recent_logs(sync_db, limit=limit, tenant_id=tenant_id)
+    )
 
 
 async def async_get_item_history(
     db: AsyncSession, name: str, tenant_id: int, limit: int = 100
 ) -> List[AuditLog]:
-    result = await db.execute(
-        select(Item).where(Item.name == name, Item.tenant_id == tenant_id)
+    """Async wrapper around :func:`get_item_history`."""
+    return await db.run_sync(
+        lambda sync_db: get_item_history(sync_db, name, tenant_id, limit)
     )
-    item = result.scalars().first()
-    if not item:
-        return []
-    result = await db.execute(
-        select(AuditLog)
-        .where(AuditLog.item_id == item.id)
-        .order_by(AuditLog.timestamp.desc())
-        .limit(limit)
-    )
-    return result.scalars().all()
 
 
 async def async_update_item(
@@ -529,36 +423,22 @@ async def async_update_item(
     status: Optional[str] = None,
     user_id: Optional[int] = None,
 ) -> Item:
-    result = await db.execute(
-        select(Item).where(Item.name == name, Item.tenant_id == tenant_id)
+    """Async wrapper around :func:`update_item`."""
+    return await db.run_sync(
+        lambda sync_db: update_item(
+            sync_db,
+            name,
+            tenant_id,
+            new_name,
+            threshold,
+            min_par,
+            department_id,
+            category_id,
+            stock_code,
+            status,
+            user_id,
+        )
     )
-    item = result.scalars().first()
-    if not item:
-        raise ValueError("Item not found")
-
-    if new_name:
-        item.name = new_name
-    if threshold is not None:
-        if threshold < 0:
-            raise ValueError("Threshold cannot be negative")
-        item.threshold = threshold
-    if min_par is not None:
-        if min_par < 0:
-            raise ValueError("min_par cannot be negative")
-        item.min_par = min_par
-    if department_id is not None:
-        item.department_id = department_id
-    if category_id is not None:
-        item.category_id = category_id
-    if stock_code is not None:
-        item.stock_code = stock_code
-    if status is not None:
-        item.status = status
-
-    await _async_log_action(db, user_id, item, "update", 0)
-    await db.commit()
-    await db.refresh(item)
-    return item
 
 
 async def async_delete_item(
@@ -567,16 +447,10 @@ async def async_delete_item(
     tenant_id: int,
     user_id: Optional[int] = None,
 ) -> None:
-    result = await db.execute(
-        select(Item).where(Item.name == name, Item.tenant_id == tenant_id)
+    """Async wrapper around :func:`delete_item`."""
+    await db.run_sync(
+        lambda sync_db: delete_item(sync_db, name, tenant_id, user_id)
     )
-    item = result.scalars().first()
-    if not item:
-        raise ValueError("Item not found")
-
-    await _async_log_action(db, user_id, item, "delete", 0)
-    await db.delete(item)
-    await db.commit()
 
 
 async def async_transfer_item(
@@ -587,38 +461,14 @@ async def async_transfer_item(
     to_tenant_id: int,
     user_id: Optional[int] = None,
 ) -> Tuple[Item, Item]:
-    """Asynchronously move stock between tenants."""
-    if qty <= 0:
-        raise ValueError("Quantity must be positive")
-
-    result = await db.execute(
-        select(Item).where(Item.name == name, Item.tenant_id == from_tenant_id)
-    )
-    from_item = result.scalars().first()
-    if not from_item or from_item.available < qty:
-        raise ValueError("Not enough stock to transfer")
-
-    result = await db.execute(
-        select(Item).where(Item.name == name, Item.tenant_id == to_tenant_id)
-    )
-    to_item = result.scalars().first()
-    if not to_item:
-        to_item = Item(
-            name=name,
-            tenant_id=to_tenant_id,
-            available=0,
-            in_use=0,
-            threshold=from_item.threshold,
+    """Async wrapper around :func:`transfer_item`."""
+    return await db.run_sync(
+        lambda sync_db: transfer_item(
+            sync_db,
+            name,
+            qty,
+            from_tenant_id,
+            to_tenant_id,
+            user_id,
         )
-        db.add(to_item)
-
-    from_item.available -= qty
-    to_item.available += qty
-
-    await _async_log_action(db, user_id, from_item, "transfer", qty)
-    await _async_log_action(db, user_id, to_item, "transfer", qty)
-
-    await db.commit()
-    await db.refresh(from_item)
-    await db.refresh(to_item)
-    return from_item, to_item
+    )


### PR DESCRIPTION
## Summary
- remove custom async implementations in `inventory_core`
- call the synchronous functions via `AsyncSession.run_sync`
- streamline imports and trim extra whitespace

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6842f1acd8f88331a63aee97dec37605