### PR TITLE
Add Playwright dashboard workflow test

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "npm run install-browsers && npx playwright test",
+    "install-browsers": "bash scripts/install_browsers.sh"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "latest",

--- a/frontend/tests/test.spec.ts
+++ b/frontend/tests/test.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+const sampleItems = [
+  { id: 1, name: 'Widget', quantity: 10, min_par: 2, category_id: 1, department_id: 1, stock_code: 'W-1', status: 'available' }
+];
+
+test('dashboard workflow login -> view -> add -> issue', async ({ page }) => {
+  await page.route('**/token', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ access_token: 'testtoken' })
+  }));
+  await page.route('**/items/status**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(sampleItems)
+  }));
+  await page.route('**/items/add', route => route.fulfill({ status: 200, body: '{}' }));
+  await page.route('**/items/issue', route => route.fulfill({ status: 200, body: '{}' }));
+
+  await page.goto('/login');
+  await page.fill('#email', 'user@example.com');
+  await page.fill('#password', 'pw');
+  await page.click('button[type=submit]');
+  await expect(page).toHaveURL('/');
+  await expect(page.getByText('Widget')).toBeVisible();
+
+  await page.goto('/add');
+  await page.fill('#name', 'New Item');
+  await page.fill('#quantity', '5');
+  await page.fill('#threshold', '1');
+  await page.click('button[type=submit]');
+  await expect(page).toHaveURL('/');
+
+  await page.goto('/issue');
+  await page.fill('#name', 'Widget');
+  await page.fill('#quantity', '2');
+  await page.click('button[type=submit]');
+  await expect(page).toHaveURL('/');
+});


### PR DESCRIPTION
## Summary
- add Playwright browser install and test scripts
- create dashboard workflow test covering login, view items, add and issue actions

## Testing
- `npm run install-browsers` *(fails: missing system dependencies)*
- `npm test` *(fails: Timed out waiting 60000ms from config.webServer.)*

------
https://chatgpt.com/codex/tasks/task_e_6842f1aedf54833183e3e1950d781fd7