### PR TITLE
Add env variable for CORS origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ SECRET_STORE_FILE=
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=admin
 NEXT_PUBLIC_API_URL=http://localhost:8000
+# Optional comma-separated list of origins allowed to access the API
+# Defaults to NEXT_PUBLIC_API_URL when unset
+CORS_ALLOW_ORIGINS=http://localhost:8000
 CELERY_BROKER_URL=redis://localhost:6379/0
 STOCK_CHECK_INTERVAL=3600
 #SLACK_WEBHOOK_URL=

--- a/README.md
+++ b/README.md
@@ -31,11 +31,12 @@ below a configured threshold, a warning is displayed during the status check.
 1. Copy `.env.example` to `.env` and adjust values. At a minimum set
    `SECRET_KEY`. `DATABASE_URL` defaults to SQLite but can be overridden.
    When running with `docker-compose` the backend container reads
-   `SECRET_KEY` from this file. Optional settings include `ADMIN_USERNAME`,
-   `ADMIN_PASSWORD`, `NEXT_PUBLIC_API_URL` for the frontend and background
-   worker variables such as `CELERY_BROKER_URL`, `STOCK_CHECK_INTERVAL`,
-   `SLACK_WEBHOOK_URL`, `SMTP_SERVER`, `ALERT_EMAIL_TO` and
-   `ALERT_EMAIL_FROM`. **Do not commit your `.env` file to version control as
+  `SECRET_KEY` from this file. Optional settings include `ADMIN_USERNAME`,
+  `ADMIN_PASSWORD`, `NEXT_PUBLIC_API_URL` for the frontend,
+  `CORS_ALLOW_ORIGINS` for allowed CORS origins and background
+  worker variables such as `CELERY_BROKER_URL`, `STOCK_CHECK_INTERVAL`,
+  `SLACK_WEBHOOK_URL`, `SMTP_SERVER`, `ALERT_EMAIL_TO` and
+  `ALERT_EMAIL_FROM`. **Do not commit your `.env` file to version control as
    it may contain secrets.**
 2. Install Python dependencies and start the API:
 
@@ -212,10 +213,11 @@ npm run dev
 
 The frontend expects the FastAPI backend to run on `http://localhost:8000`. If your API is available elsewhere set the environment variable `NEXT_PUBLIC_API_URL` before starting the dev server.
 
-The backend now enables CORS using FastAPI's `CORSMiddleware`. When the
+The backend enables CORS using FastAPI's `CORSMiddleware`. When the
 application runs with the default SQLite database (development mode), all
-origins are allowed. In other environments requests are only accepted from the
-origin specified in `NEXT_PUBLIC_API_URL`.
+origins are allowed. In other environments the list of allowed origins is
+read from the `CORS_ALLOW_ORIGINS` variable. If unset, it defaults to the value
+of `NEXT_PUBLIC_API_URL`.
 
 After logging in you will see the dashboard listing all items. Links are provided to pages for adding new stock, issuing items and recording returns. Each form uses the JWT token stored in `localStorage` to authenticate API requests.
 

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+
 try:
     from pydantic_settings import BaseSettings  # type: ignore
     from pydantic import Field, ConfigDict
@@ -8,6 +9,7 @@ except Exception:  # fallback if package missing or using pydantic v1
     except Exception:
         from pydantic import BaseSettings  # type: ignore
     from pydantic import Field
+
     ConfigDict = None
 
 from secrets_manager import get_manager
@@ -17,15 +19,18 @@ class Settings(BaseSettings):
     if ConfigDict is not None:
         model_config = ConfigDict(extra="ignore", env_file=".env")
     else:
+
         class Config:
             extra = "ignore"
             env_file = ".env"
+
     database_url: str = Field("sqlite:///./inventory.db", env="DATABASE_URL")
     secret_key: str | None = Field(None, env="SECRET_KEY")
     secret_store_file: str | None = Field(None, env="SECRET_STORE_FILE")
     admin_username: str | None = Field(None, env="ADMIN_USERNAME")
     admin_password: str | None = Field(None, env="ADMIN_PASSWORD")
     next_public_api_url: str | None = Field(None, env="NEXT_PUBLIC_API_URL")
+    cors_allow_origins: str | None = Field(None, env="CORS_ALLOW_ORIGINS")
     celery_broker_url: str = Field("redis://localhost:6379/0", env="CELERY_BROKER_URL")
     stock_check_interval: int = Field(3600, env="STOCK_CHECK_INTERVAL")
     async_database_url: str | None = Field(None, env="ASYNC_DATABASE_URL")

--- a/main.py
+++ b/main.py
@@ -56,8 +56,11 @@ app = FastAPI(
 ws_manager = InventoryWSManager()
 
 # Configure CORS
-frontend_origin = settings.next_public_api_url
-origins = [frontend_origin] if frontend_origin else []
+origins_raw = settings.cors_allow_origins or settings.next_public_api_url
+if origins_raw:
+    origins = [o.strip() for o in origins_raw.split(",") if o.strip()]
+else:
+    origins = []
 if DATABASE_URL.startswith("sqlite"):
     origins = ["*"]
 


### PR DESCRIPTION
## Summary
- allow overriding CORS origins with `CORS_ALLOW_ORIGINS`
- document the new setting in `.env.example` and README

## Testing
- `black config.py main.py`
- `pip install -q -r requirements.txt` *(fails: Getting requirements to build wheel)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6842f1bcc5188331a67870f83a17f22c