### PR TITLE
Add indexes for items and audit logs

### DIFF
--- a/alembic/versions/20240607_add_indexes.py
+++ b/alembic/versions/20240607_add_indexes.py
@@ -1,0 +1,19 @@
+"""create indexes on frequently queried columns"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20240607_add_indexes'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('ix_items_name', 'items', ['name'])
+    op.create_index('ix_audit_logs_timestamp', 'audit_logs', ['timestamp'])
+
+
+def downgrade():
+    op.drop_index('ix_audit_logs_timestamp', table_name='audit_logs')
+    op.drop_index('ix_items_name', table_name='items')


### PR DESCRIPTION
## Summary
- create alembic migration to index `items.name` and `audit_logs.timestamp`

## Testing
- `pytest -q` *(fails: ImportError from fastapi because pydantic 2.x is installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842f1bb54c48331bf1ae6fbf67ccc42