### PR TITLE
Fix browser helper doc path

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -12,6 +12,6 @@ This directory contains the Next.js interface managed by the **frontend-agent**.
 - Start the development server using `npm run dev`.
 - The API base URL defaults to `http://localhost:8000` but can be overridden via `NEXT_PUBLIC_API_URL`.
 - Keep components simple and avoid heavy UI frameworks.
-- Before running Playwright tests, execute `npx playwright install` to download the required browser binaries. A helper script is available at `scripts/install_browsers.sh`.
+- Before running Playwright tests, execute `npx playwright install` to download the required browser binaries. A helper script is available at `frontend/scripts/install_browsers.sh` and should be run from the `frontend` directory.
 - Run browser tests using `npx playwright test`.
 


### PR DESCRIPTION
## Summary
- update `frontend/AGENTS.md` to reference the helper script at `frontend/scripts/install_browsers.sh`
- clarify that the script should be run from the `frontend` directory

## Testing
- `npx markdownlint-cli frontend/AGENTS.md` *(fails: MD012/no-multiple-blanks etc.)*
- `pytest -q` *(fails: TypeError: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6842f21f2e6483319d70873756697906