### PR TITLE
Add test for rate limiter on token endpoint

### DIFF
--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,16 @@
+from tests.conftest import get_token
+
+
+def test_rate_limiter_blocks_excess_token_requests(client):
+    # Send five successful token requests within the rate limit
+    for _ in range(5):
+        token = get_token(client)
+        assert token
+
+    # Sixth request should exceed the limit and return HTTP 429
+    resp = client.post(
+        "/token",
+        data={"username": "admin", "password": "admin"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- add `tests/test_rate_limiter.py` to ensure exceeding `/token` requests hits HTTP 429

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f2206c8c8331966ad8b00731f62c