### PR TITLE
Remove duplicate field updates in update_item

### DIFF
--- a/inventory_core.py
+++ b/inventory_core.py
@@ -227,54 +227,6 @@ def update_item(
         item.stock_code = stock_code
     if status is not None:
         item.status = status
-    if min_par is not None:
-        if min_par < 0:
-            raise ValueError("min_par cannot be negative")
-        item.min_par = min_par
-    if department_id is not None:
-        item.department_id = department_id
-    if category_id is not None:
-        item.category_id = category_id
-    if stock_code is not None:
-        item.stock_code = stock_code
-    if status is not None:
-        item.status = status
-    if min_par is not None:
-        if min_par < 0:
-            raise ValueError("min_par cannot be negative")
-        item.min_par = min_par
-    if department_id is not None:
-        item.department_id = department_id
-    if category_id is not None:
-        item.category_id = category_id
-    if stock_code is not None:
-        item.stock_code = stock_code
-    if status is not None:
-        item.status = status
-    if min_par is not None:
-        if min_par < 0:
-            raise ValueError("min_par cannot be negative")
-        item.min_par = min_par
-    if department_id is not None:
-        item.department_id = department_id
-    if category_id is not None:
-        item.category_id = category_id
-    if stock_code is not None:
-        item.stock_code = stock_code
-    if status is not None:
-        item.status = status
-    if min_par is not None:
-        if min_par < 0:
-            raise ValueError("min_par cannot be negative")
-        item.min_par = min_par
-    if department_id is not None:
-        item.department_id = department_id
-    if category_id is not None:
-        item.category_id = category_id
-    if stock_code is not None:
-        item.stock_code = stock_code
-    if status is not None:
-        item.status = status
 
     _log_action(db, user_id, item, "update", 0)
     db.commit()


### PR DESCRIPTION
## Summary
- refactor `inventory_core.update_item` to avoid repeated validation and assignment
- test `update_item` negative min_par validation and audit log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f2285adc833191fbd3edfd6a4b3b