### PR TITLE
Rename register department_id field

### DIFF
--- a/routers/auth.py
+++ b/routers/auth.py
@@ -22,10 +22,10 @@ def register(payload: RegisterRequest, db: Session = Depends(get_db)):
     if db.query(User).filter(User.username == payload.email).first():
         raise HTTPException(status_code=400, detail="Username already registered")
 
-    if payload.department_id is not None:
-        tenant = db.query(Tenant).filter(Tenant.id == payload.department_id).first()
+    if payload.tenant_id is not None:
+        tenant = db.query(Tenant).filter(Tenant.id == payload.tenant_id).first()
         if not tenant:
-            raise HTTPException(status_code=404, detail="Department not found")
+            raise HTTPException(status_code=404, detail="Tenant not found")
     else:
         tenant = Tenant(name=payload.email)
         db.add(tenant)

--- a/schemas.py
+++ b/schemas.py
@@ -167,5 +167,5 @@ class PasswordResetConfirm(BaseModel):
 class RegisterRequest(BaseModel):
     email: str
     password: str
-    department_id: int | None = None
+    tenant_id: int | None = None
     is_admin: bool = False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -253,9 +253,9 @@ def test_register_duplicate_username(client):
     second = client.post("/auth/register", json=payload)
     assert second.status_code == 400
 
-def test_register_missing_department(client):
+def test_register_missing_tenant(client):
     resp = client.post(
         "/auth/register",
-        json={"email": "nodpt@example.com", "password": "pw", "department_id": 99},
+        json={"email": "nodpt@example.com", "password": "pw", "tenant_id": 99},
     )
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- refactor `RegisterRequest` to accept `tenant_id`
- update `/auth/register` logic for `tenant_id`
- adjust tests for renamed field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f1f5331c8331a6916f06aa4a19d8