### PR TITLE
Fix SQLAlchemy postgres URL and add memory rate limiter

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,6 +33,7 @@ class Settings(BaseSettings):
     cors_allow_origins: str | None = Field(None, env="CORS_ALLOW_ORIGINS")
     celery_broker_url: str = Field("redis://localhost:6379/0", env="CELERY_BROKER_URL")
     redis_url: str = Field("redis://localhost:6379/1", env="REDIS_URL")
+    rate_limit_redis_url: str = Field("memory://", env="RATE_LIMIT_REDIS_URL")
     stock_check_interval: int = Field(3600, env="STOCK_CHECK_INTERVAL")
     async_database_url: str | None = Field(None, env="ASYNC_DATABASE_URL")
     slack_webhook_url: str | None = Field(None, env="SLACK_WEBHOOK_URL")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build: .
     container_name: backend
     environment:
-      DATABASE_URL: postgres://${POSTGRES_USER:-stock}:${POSTGRES_PASSWORD:-stock}@db:5432/${POSTGRES_DB:-stockdb}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-stock}:${POSTGRES_PASSWORD:-stock}@db:5432/${POSTGRES_DB:-stockdb}
       SECRET_KEY: ${SECRET_KEY}
       ADMIN_USERNAME: admin
       ADMIN_PASSWORD: admin
@@ -26,7 +26,7 @@ services:
     build: .
     command: celery -A tasks worker --loglevel=info
     environment:
-      DATABASE_URL: postgres://${POSTGRES_USER:-stock}:${POSTGRES_PASSWORD:-stock}@db:5432/${POSTGRES_DB:-stockdb}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-stock}:${POSTGRES_PASSWORD:-stock}@db:5432/${POSTGRES_DB:-stockdb}
       CELERY_BROKER_URL: redis://redis:6379/0
     depends_on:
       - db
@@ -35,7 +35,7 @@ services:
     build: .
     command: celery -A tasks beat --loglevel=info
     environment:
-      DATABASE_URL: postgres://${POSTGRES_USER:-stock}:${POSTGRES_PASSWORD:-stock}@db:5432/${POSTGRES_DB:-stockdb}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-stock}:${POSTGRES_PASSWORD:-stock}@db:5432/${POSTGRES_DB:-stockdb}
       CELERY_BROKER_URL: redis://redis:6379/0
     depends_on:
       - db

--- a/rate_limiter.py
+++ b/rate_limiter.py
@@ -1,5 +1,6 @@
 from typing import Iterable
 import time
+from collections import defaultdict
 
 import redis.asyncio as redis
 
@@ -15,25 +16,34 @@ class RateLimiter:
         self.window = window
         self.routes = list(routes)
         self.redis_url = redis_url
+        self._memory_store = defaultdict(list) if redis_url == "memory://" else None
 
     async def __call__(self, request: Request, call_next):
         if any(request.url.path.startswith(route) for route in self.routes):
             key = f"rl:{request.client.host}:{request.url.path}"
             now = int(time.time())
-            async with redis.from_url(self.redis_url, decode_responses=True) as r:
-                await r.zremrangebyscore(key, 0, now - self.window)
-                count = await r.zcard(key)
-                if count >= self.limit:
-                    return JSONResponse(
-                        status_code=429, content={"detail": "Too many requests"}
-                    )
-                await r.zadd(key, {str(now): now})
-                await r.expire(key, self.window)
+            if self._memory_store is not None:
+                queue = [t for t in self._memory_store[key] if t > now - self.window]
+                if len(queue) >= self.limit:
+                    return JSONResponse(status_code=429, content={"detail": "Too many requests"})
+                queue.append(now)
+                self._memory_store[key] = queue
+            else:
+                async with redis.from_url(self.redis_url, decode_responses=True) as r:
+                    await r.zremrangebyscore(key, 0, now - self.window)
+                    count = await r.zcard(key)
+                    if count >= self.limit:
+                        return JSONResponse(status_code=429, content={"detail": "Too many requests"})
+                    await r.zadd(key, {str(now): now})
+                    await r.expire(key, self.window)
         response = await call_next(request)
         return response
 
     async def reset(self) -> None:
-        async with redis.from_url(self.redis_url, decode_responses=True) as r:
-            keys = await r.keys("rl:*")
-            if keys:
-                await r.delete(*keys)
+        if self._memory_store is not None:
+            self._memory_store.clear()
+        else:
+            async with redis.from_url(self.redis_url, decode_responses=True) as r:
+                keys = await r.keys("rl:*")
+                if keys:
+                    await r.delete(*keys)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pydantic-settings
 redis
 pyotp
 PyYAML>=6.0.1
+psycopg2-binary


### PR DESCRIPTION
## Summary
- correct postgres connection string in `docker-compose.yml`
- add `psycopg2-binary` dependency
- support a memory-based fallback for the rate limiter
- expose `RATE_LIMIT_REDIS_URL` setting with a default of `memory://`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: 10 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6842f89871e48331bfaac06786e81ddf