### PR TITLE
Fix API paths for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,8 +251,7 @@ this step.
 ## User registration
 
 New users can sign up via the `/register` page in the Next.js frontend. The form
-submits to `/api/auth/register` which proxies to the FastAPI endpoint
-`/auth/register`. When departments exist the page lets users choose one; otherwise
+submits directly to the FastAPI endpoint `/auth/register`. When departments exist the page lets users choose one; otherwise
 a tenant is created automatically. On success the user is redirected to the login
 screen.
 

--- a/frontend/components/RegisterForm.tsx
+++ b/frontend/components/RegisterForm.tsx
@@ -21,7 +21,7 @@ export default function RegisterForm() {
   useEffect(() => {
     const fetchDepartments = async () => {
       try {
-        const data = await apiGet<Department[]>('/api/departments/public');
+        const data = await apiGet<Department[]>('/departments/public');
         setDepartments(data);
         setShowDepartments(true);
       } catch (err) {
@@ -47,7 +47,7 @@ export default function RegisterForm() {
     setIsLoading(true);
 
     try {
-      await apiPost('/api/auth/register', {
+      await apiPost('/auth/register', {
         email,
         password,
         department_id: showDepartments && departmentId ? departmentId : null,

--- a/frontend/components/stock-dashboard.tsx
+++ b/frontend/components/stock-dashboard.tsx
@@ -203,7 +203,7 @@ export function StockDashboard() {
       try {
         // Fetch departments with loading state
         setIsLoading(prev => ({ ...prev, departments: true }));
-        const fetchedDepartments = await apiGet<Department[]>('/api/departments/');
+        const fetchedDepartments = await apiGet<Department[]>('/departments/');
         if (Array.isArray(fetchedDepartments) && fetchedDepartments.length > 0) {
           setDepartments(fetchedDepartments);
           console.log("Fetched departments:", fetchedDepartments);
@@ -214,7 +214,7 @@ export function StockDashboard() {
         
         // Fetch categories with loading state
         setIsLoading(prev => ({ ...prev, categories: true }));
-        const fetchedCategories = await apiGet<Category[]>('/api/categories/');
+        const fetchedCategories = await apiGet<Category[]>('/categories/');
         if (Array.isArray(fetchedCategories)) {
           setCategories(fetchedCategories);
           console.log("Fetched categories:", fetchedCategories);
@@ -341,7 +341,7 @@ export function StockDashboard() {
   const handleAddEditItemSubmit = async (itemData: Omit<StockItem, "id">) => {
     if (addEditInitialItem) {
       try {
-        const updated = await apiFetch<StockItem>("/api/items/update", {
+          const updated = await apiFetch<StockItem>("/items/update", {
           method: "PUT",
           body: { id: addEditInitialItem.id, ...itemData },
         })
@@ -355,7 +355,7 @@ export function StockDashboard() {
       }
     } else {
       try {
-        const created = await apiFetch<StockItem>("/api/items/add", {
+          const created = await apiFetch<StockItem>("/items/add", {
           method: "POST",
           body: itemData,
         })
@@ -382,7 +382,7 @@ export function StockDashboard() {
     }
 
     try {
-      const response = await apiPost<Department>('/api/departments/', {
+      const response = await apiPost<Department>('/departments/', {
         name: newDepartmentName,
         icon: newDepartmentIcon || "Computer"
       });
@@ -425,7 +425,7 @@ export function StockDashboard() {
       setIsLoading(prev => ({ ...prev, categories: true }));
       
       console.log("Creating category with data:", categoryData);
-      const newCategory = await apiFetch<Category>("/api/categories/", {
+        const newCategory = await apiFetch<Category>("/categories/", {
         method: "POST",
         body: {
           name: categoryData.name,
@@ -438,7 +438,7 @@ export function StockDashboard() {
       // Only update UI after successful API call
       if (newCategory && typeof newCategory.id === 'number') {
         // Refresh the entire categories list to ensure consistency
-        const refreshedCategories = await apiGet<Category[]>('/api/categories/');
+          const refreshedCategories = await apiGet<Category[]>('/categories/');
         if (Array.isArray(refreshedCategories)) {
           setCategories(refreshedCategories);
         } else {
@@ -760,7 +760,7 @@ export function StockDashboard() {
 
   const handleConfirmDelete = async () => {
     if (deleteType === "department") {
-      await apiFetch(`/api/departments/${deleteId}`, { method: "DELETE" })
+        await apiFetch(`/departments/${deleteId}`, { method: "DELETE" })
       setDepartments(departments.filter((dept) => dept.id !== deleteId))
       setCategories(categories.filter((cat) => cat.department_id !== deleteId))
       if (selectedDepartment === deleteId) {
@@ -771,7 +771,7 @@ export function StockDashboard() {
         description: "Department and its categories have been removed",
       })
     } else {
-      await apiFetch(`/api/categories/${deleteId}`, { method: "DELETE" })
+        await apiFetch(`/categories/${deleteId}`, { method: "DELETE" })
       setCategories(categories.filter((cat) => cat.id !== deleteId))
       toast({
         title: "Category Deleted",
@@ -781,7 +781,7 @@ export function StockDashboard() {
   }
 
   const handleSaveDepartment = async (updatedDepartment: Department) => {
-    const res = await apiFetch<Department>(`/api/departments/${updatedDepartment.id}`, {
+      const res = await apiFetch<Department>(`/departments/${updatedDepartment.id}`, {
       method: "PUT",
       body: updatedDepartment,
     })
@@ -793,7 +793,7 @@ export function StockDashboard() {
   }
 
   const handleSaveCategory = async (updatedCategory: Category) => {
-    const res = await apiFetch<Category>(`/api/categories/${updatedCategory.id}`, {
+      const res = await apiFetch<Category>(`/categories/${updatedCategory.id}`, {
       method: "PUT",
       body: updatedCategory,
     })
@@ -839,7 +839,7 @@ export function StockDashboard() {
     if (!deleteItem) return;
 
     try {
-      await apiFetch("/api/items/delete", {
+      await apiFetch("/items/delete", {
         method: "DELETE",
         body: { id: deleteItem.id },
       })


### PR DESCRIPTION
## Summary
- fix front-end API URLs to call FastAPI endpoints directly
- update README registration instructions

## Testing
- `pytest -q` *(fails: 8 failed, 27 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6842fb7cdd088331835c5afff1e9a7c4