### PR TITLE
Fix landing page auth redirect

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,5 +1,19 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 import { StockDashboard } from '@/components/stock-dashboard';
+import { useAuth } from '@/lib/auth-context';
 
 export default function Home() {
+  const router = useRouter();
+  const { isAuthenticated } = useAuth();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      router.replace('/login');
+    }
+  }, [isAuthenticated, router]);
+
+  if (!isAuthenticated) return null;
+
   return <StockDashboard />;
 }


### PR DESCRIPTION
## Summary
- redirect home page to `/login` when not authenticated

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6842fbad435c833183f0d310db6286ff