### PR TITLE
Fix login with TOTP

### DIFF
--- a/frontend/components/LoginForm.tsx
+++ b/frontend/components/LoginForm.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/lib/auth-context';
 export default function LoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [totp, setTotp] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const { login } = useAuth();
@@ -17,7 +18,7 @@ export default function LoginForm() {
     setIsLoading(true);
 
     try {
-      await login(email, password);
+      await login(email, password, totp);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed. Please try again.');
     } finally {
@@ -52,7 +53,7 @@ export default function LoginForm() {
           />
         </div>
         
-        <div className="mb-6">
+        <div className="mb-4">
           <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
             Password
           </label>
@@ -65,7 +66,20 @@ export default function LoginForm() {
             required
           />
         </div>
-        
+        <div className="mb-6">
+          <label htmlFor="totp" className="block text-sm font-medium text-gray-700 mb-1">
+            Two-Factor Code
+          </label>
+          <input
+            id="totp"
+            type="text"
+            value={totp}
+            onChange={(e) => setTotp(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+
         <button
           type="submit"
           disabled={isLoading}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -49,10 +49,11 @@ export const apiGet = <T>(path: string, options?: ApiFetchOptions) =>
 export const apiPost = <T>(path: string, body?: any, options?: ApiFetchOptions) =>
   apiFetch<T>(path, { method: 'POST', body, ...(options || {}) });
 
-export async function login(username: string, password: string) {
+export async function login(username: string, password: string, totp: string) {
   const body = new URLSearchParams();
   body.set('username', username);
   body.set('password', password);
+  body.set('totp', totp);
   const res = await apiPost<{ access_token: string }>('/token', body);
   return res.access_token;
 }

--- a/frontend/lib/auth-context.tsx
+++ b/frontend/lib/auth-context.tsx
@@ -7,7 +7,7 @@ interface AuthContextType {
   isAuthenticated: boolean;
   /** optional user object for role based checks */
   user: any | null;
-  login: (username: string, password: string) => Promise<void>;
+  login: (username: string, password: string, totp: string) => Promise<void>;
   logout: () => void;
 }
 
@@ -30,8 +30,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   }, []);
 
-  const login = async (username: string, password: string) => {
-    const t = await apiLogin(username, password);
+  const login = async (username: string, password: string, totp: string) => {
+    const t = await apiLogin(username, password, totp);
     localStorage.setItem('token', t);
     setToken(t);
   };

--- a/routers/users.py
+++ b/routers/users.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 
 from database import get_db
 from models import User
+import pyotp
 from schemas import UserCreate, UserResponse, UserUpdate, UserDelete
 from auth import require_role, get_password_hash, ensure_tenant
 
@@ -30,6 +31,7 @@ def create_user(
         role=payload.role,
         tenant_id=payload.tenant_id,
         notification_preference=payload.notification_preference,
+        totp_secret=pyotp.random_base32(),
     )
     db.add(new_user)
     db.commit()


### PR DESCRIPTION
## Summary
- include `totp` field in login form and API helper
- update auth context to pass two-factor codes
- ensure user creation assigns a TOTP secret

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: NOT NULL constraint failed: users.totp_secret)*

------
https://chatgpt.com/codex/tasks/task_e_6842fbc25b74833190592f12f5f179f8