### PR TITLE
Fix dark mode toggle

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,11 +1,14 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
 import { AuthProvider } from '@/lib/auth-context';
+import { ThemeProvider } from '@/components/theme-provider';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <AuthProvider>
-      <Component {...pageProps} />
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        <Component {...pageProps} />
+      </ThemeProvider>
     </AuthProvider>
   );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,6 +5,7 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx}',
     './app/**/*.{js,ts,jsx,tsx}'
   ],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- add ThemeProvider wrapper to MyApp
- enable class-based dark mode in Tailwind

## Testing
- `pytest -q` *(fails: multi_tenant_isolation, transfer_endpoint_and_history, register endpoints, dashboard_workflow_not_supported, notification_logs_created, websocket inventory updates)*

------
https://chatgpt.com/codex/tasks/task_e_6843030717e083319f6e73bbd85c38fc