### PR TITLE
Fix missing pyotp import

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from starlette.websockets import WebSocketDisconnect
 from sqlalchemy.orm import Session
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
+import pyotp
 from jose import JWTError, jwt
 
 from database import Base, engine, get_db, SessionLocal, DATABASE_URL


### PR DESCRIPTION
## Summary
- include pyotp in main app module

## Testing
- `flake8`
- `pytest -q` *(fails: too many values to unpack, sqlite integrity errors)*

------
https://chatgpt.com/codex/tasks/task_e_6843030f565c83318c77c93ab482d88b