### PR TITLE
Add frontend quickstart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ curl -H "Authorization: Bearer <token>" \
 ## Running the Frontend
 
 A simple Next.js interface lives in the `frontend/` folder. It uses the API server described above.
+See [frontend/README.md](frontend/README.md) for a quickstart guide.
 
 ```bash
 # install frontend dependencies

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,18 @@
+# Frontend Quickstart
+
+Install dependencies and start the Next.js app:
+
+```bash
+npm install
+npm run dev
+```
+
+Run the Playwright tests (browsers will be installed automatically):
+
+```bash
+npm run test
+```
+
+Set `NEXT_PUBLIC_API_URL` if your API is running on a different URL than `http://localhost:8000`.
+
+For additional details see [AGENTS.md](./AGENTS.md).


### PR DESCRIPTION
## Summary
- document Next.js setup and testing in `frontend/README.md`
- link to the new README from root `README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6843073fba488331bc04769483c1935d