### PR TITLE
Disable TOTP and adjust tests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,6 +19,6 @@ This document highlights major milestones for the inventory SaaS platform.
 - Extended integration tests and data factories
 
 ## Planned
-- Two-factor authentication and password reset
+- Password reset
 - Additional performance tuning and async optimisations
 - More notification options (email/Slack)

--- a/alembic/versions/20240608_remove_totp.py
+++ b/alembic/versions/20240608_remove_totp.py
@@ -1,0 +1,17 @@
+"""remove totp column"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20240608_remove_totp'
+down_revision = '20240607_add_totp'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column('users', 'totp_secret')
+
+
+def downgrade():
+    op.add_column('users', sa.Column('totp_secret', sa.String(), nullable=True))

--- a/frontend/components/LoginForm.tsx
+++ b/frontend/components/LoginForm.tsx
@@ -7,7 +7,6 @@ import { useAuth } from '@/lib/auth-context';
 export default function LoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [totp, setTotp] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const { login } = useAuth();
@@ -18,7 +17,7 @@ export default function LoginForm() {
     setIsLoading(true);
 
     try {
-      await login(email, password, totp);
+      await login(email, password);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed. Please try again.');
     } finally {
@@ -62,19 +61,6 @@ export default function LoginForm() {
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            required
-          />
-        </div>
-        <div className="mb-6">
-          <label htmlFor="totp" className="block text-sm font-medium text-gray-700 mb-1">
-            Two-Factor Code
-          </label>
-          <input
-            id="totp"
-            type="text"
-            value={totp}
-            onChange={(e) => setTotp(e.target.value)}
             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
             required
           />

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -49,11 +49,10 @@ export const apiGet = <T>(path: string, options?: ApiFetchOptions) =>
 export const apiPost = <T>(path: string, body?: any, options?: ApiFetchOptions) =>
   apiFetch<T>(path, { method: 'POST', body, ...(options || {}) });
 
-export async function login(username: string, password: string, totp: string) {
+export async function login(username: string, password: string) {
   const body = new URLSearchParams();
   body.set('username', username);
   body.set('password', password);
-  body.set('totp', totp);
   const res = await apiPost<{ access_token: string }>('/token', body);
   return res.access_token;
 }

--- a/frontend/lib/auth-context.tsx
+++ b/frontend/lib/auth-context.tsx
@@ -7,7 +7,7 @@ interface AuthContextType {
   isAuthenticated: boolean;
   /** optional user object for role based checks */
   user: any | null;
-  login: (username: string, password: string, totp: string) => Promise<void>;
+  login: (username: string, password: string) => Promise<void>;
   logout: () => void;
 }
 
@@ -30,8 +30,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   }, []);
 
-  const login = async (username: string, password: string, totp: string) => {
-    const t = await apiLogin(username, password, totp);
+  const login = async (username: string, password: string) => {
+    const t = await apiLogin(username, password);
     localStorage.setItem('token', t);
     setToken(t);
   };

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import asyncio
 
 from config import settings
 
-from fastapi import FastAPI, HTTPException, Depends, WebSocket, Form
+from fastapi import FastAPI, HTTPException, Depends, WebSocket
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -10,7 +10,6 @@ from starlette.websockets import WebSocketDisconnect
 from sqlalchemy.orm import Session
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
-import pyotp
 from jose import JWTError, jwt
 
 from database import Base, engine, get_db, SessionLocal, DATABASE_URL
@@ -164,7 +163,6 @@ def create_default_admin():
             hashed_password=get_password_hash(password),
             role="admin",
             tenant_id=tenant.id,
-            totp_secret=pyotp.random_base32(),
             notification_preference="email",
         )
         db.add(admin)
@@ -180,8 +178,7 @@ any_user = require_role(["admin", "manager", "user"])
 @app.post("/token")
 async def login(
     form_data: OAuth2PasswordRequestForm = Depends(),
-    totp: str = Form(...),
     db: AsyncSession = Depends(get_async_db),
 ):
     """Authenticate a user and return a JWT access token."""
-    return await login_for_access_token(form_data, totp, db)
+    return await login_for_access_token(form_data, db)

--- a/models.py
+++ b/models.py
@@ -68,7 +68,6 @@ class User(Base):
     hashed_password = Column(String)
     role = Column(String, default="user")
     tenant_id = Column(Integer, ForeignKey("tenants.id"))
-    totp_secret = Column(String, nullable=False)
     # "email", "slack" or "none"
     notification_preference = Column(String, default="email")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,5 @@ python-dotenv
 pytest
 pydantic-settings
 redis
-pyotp
 PyYAML>=6.0.1
 psycopg2-binary

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 import secrets
-import pyotp
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
@@ -35,19 +34,17 @@ def register(payload: RegisterRequest, db: Session = Depends(get_db)):
         db.refresh(tenant)
 
     role = "admin" if payload.is_admin else "user"
-    secret = pyotp.random_base32()
     user = User(
         username=payload.email,
         hashed_password=get_password_hash(payload.password),
         role=role,
         tenant_id=tenant.id,
-        totp_secret=secret,
         notification_preference="email",
     )
     db.add(user)
     db.commit()
     db.refresh(user)
-    return RegisterResponse(user=user, totp_secret=secret)
+    return RegisterResponse(user=user)
 
 
 @router.post("/request-reset")

--- a/routers/users.py
+++ b/routers/users.py
@@ -3,7 +3,6 @@ from sqlalchemy.orm import Session
 
 from database import get_db
 from models import User
-import pyotp
 from schemas import UserCreate, UserResponse, UserUpdate, UserDelete
 from auth import require_role, get_password_hash, ensure_tenant
 
@@ -31,7 +30,6 @@ def create_user(
         role=payload.role,
         tenant_id=payload.tenant_id,
         notification_preference=payload.notification_preference,
-        totp_secret=pyotp.random_base32(),
     )
     db.add(new_user)
     db.commit()

--- a/schemas.py
+++ b/schemas.py
@@ -177,4 +177,3 @@ class RegisterRequest(BaseModel):
 
 class RegisterResponse(BaseModel):
     user: UserResponse
-    totp_secret: str

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,4 @@
 from tests.conftest import get_token
-import pyotp
 
 def test_multi_tenant_isolation(client):
     from models import Tenant, User
@@ -13,23 +12,20 @@ def test_multi_tenant_isolation(client):
     _session.commit()
     _session.refresh(tenant2)
 
-    admin2_secret = pyotp.random_base32()
     admin2 = User(
         username="admin2",
         hashed_password=get_password_hash("admin2"),
         role="admin",
         tenant_id=tenant2.id,
-        totp_secret=admin2_secret,
         notification_preference="email",
     )
     _session.add(admin2)
     _session.commit()
 
     token1 = get_token(client)
-    otp2 = pyotp.TOTP(admin2_secret).now()
     resp = client.post(
         "/token",
-        data={"username": "admin2", "password": "admin2", "totp": otp2},
+        data={"username": "admin2", "password": "admin2"},
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
     assert resp.status_code == 200
@@ -253,7 +249,6 @@ def test_register_success(client):
     data = resp.json()
     assert data["user"]["username"] == "new@example.com"
     assert data["user"]["tenant_id"]
-    assert "totp_secret" in data
 
 def test_register_duplicate_username(client):
     payload = {"email": "dup@example.com", "password": "x"}

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -4,7 +4,6 @@ from fastapi.testclient import TestClient
 import httpx
 import pytest
 import inspect
-import pyotp
 import tests.conftest as conf
 
 # Setup temporary SQLite DB path
@@ -60,13 +59,11 @@ def client():
             adb.add(tenant)
             await adb.commit()
             await adb.refresh(tenant)
-            conf.ADMIN_TOTP_SECRET = pyotp.random_base32()
             admin = User(
                 username="admin",
                 hashed_password=get_password_hash("admin"),
                 role="admin",
                 tenant_id=tenant.id,
-                totp_secret=conf.ADMIN_TOTP_SECRET,
                 notification_preference="email",
             )
             adb.add(admin)
@@ -101,10 +98,9 @@ def client():
 
 
 def _get_token(client: TestClient) -> str:
-    otp = pyotp.TOTP(conf.ADMIN_TOTP_SECRET).now()
     resp = client.post(
         "/token",
-        data={"username": "admin", "password": "admin", "totp": otp},
+        data={"username": "admin", "password": "admin"},
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
     assert (


### PR DESCRIPTION
## Summary
- drop TOTP field from users and registration responses
- remove TOTP handling in auth logic and startup admin creation
- simplify frontend login to use only username and password
- clean up tests and requirements accordingly
- adjust roadmap

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: test_multi_tenant_isolation, test_transfer_endpoint_and_history, test_dashboard_workflow_not_supported, test_websocket_receives_inventory_updates, test_websocket_transfer_notification)*

------
https://chatgpt.com/codex/tasks/task_e_684310b9461083319679b527a667ce59