### PR TITLE
Increase Playwright timeout

### DIFF
--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -6,7 +6,8 @@ const config = {
     command: 'npm run build && npx next start -p 3000',
     port: 3000,
     reuseExistingServer: true,
-    timeout: 120 * 1000,
+    // Build can take a while on fresh installs, so allow up to 5 minutes
+    timeout: 300 * 1000,
   },
   use: {
     baseURL: 'http://localhost:3000',


### PR DESCRIPTION
## Summary
- extend the Playwright web server timeout so builds have more time to start

## Testing
- `pytest -q` *(fails: 6 failed)*
- `npx --prefix frontend playwright test` *(fails: 7 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6843135f5a588331b54a4b076cac45e2