### PR TITLE
Fix docker CORS env defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,10 +16,15 @@ SECRET_STORE_FILE=
 
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=admin
-NEXT_PUBLIC_API_URL=http://localhost:8000
-# Optional comma-separated list of origins allowed to access the API
-# Defaults to NEXT_PUBLIC_API_URL when unset
-CORS_ALLOW_ORIGINS=http://localhost:8000
+# API base URL used by the frontend.
+# When running with docker-compose the backend container is reachable at
+# http://backend:8000. For local development outside Docker you can use
+# http://localhost:8000 instead.
+NEXT_PUBLIC_API_URL=http://backend:8000
+# Optional comma-separated list of origins allowed to access the API.
+# Defaults to NEXT_PUBLIC_API_URL when unset. Set to the URL of the frontend
+# when using docker-compose so browsers can make requests.
+CORS_ALLOW_ORIGINS=http://localhost:3000
 CELERY_BROKER_URL=redis://localhost:6379/0
 RATE_LIMIT_REDIS_URL=redis://localhost:6379/1
 REDIS_URL=redis://localhost:6379/1

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ below a configured threshold, a warning is displayed during the status check.
   worker variables such as `CELERY_BROKER_URL`, `STOCK_CHECK_INTERVAL`,
   `SLACK_WEBHOOK_URL`, `SMTP_SERVER`, `ALERT_EMAIL_TO` and
   `ALERT_EMAIL_FROM`. **Do not commit your `.env` file to version control as
-   it may contain secrets.**
+  it may contain secrets.**
+   When using `docker-compose`, set `NEXT_PUBLIC_API_URL` to
+  `http://backend:8000` and `CORS_ALLOW_ORIGINS` to `http://localhost:3000`.
 2. Install Python dependencies and start the API:
 
 ```bash
@@ -271,6 +273,10 @@ To start the backend together with a PostgreSQL database and the Next.js fronten
 ```bash
 cp .env.example .env
 # edit values as needed; docker-compose reads variables from this file
+# When running the containers you should point the frontend at the
+# backend service and allow requests from the browser:
+# NEXT_PUBLIC_API_URL=http://backend:8000
+# CORS_ALLOW_ORIGINS=http://localhost:3000
 docker-compose up --build
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       context: ./frontend/
     container_name: frontend
     environment:
-      NEXT_PUBLIC_API_URL: http://localhost:8000
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://backend:8000}
     depends_on:
       - backend
     ports:


### PR DESCRIPTION
## Summary
- update default API URL and CORS settings for Docker usage
- note required values in README

## Testing
- `pytest -q` *(fails: Token request failed)*
- `npx playwright test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_684344f59eec833196464c33373aeb7c