### PR TITLE
Fix login form encoding

### DIFF
--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -19,7 +19,12 @@ export async function apiFetch<T>(
   }
 
   let body = opts.body;
-  if (body && typeof body === 'object' && !(body instanceof FormData)) {
+  if (
+    body &&
+    typeof body === 'object' &&
+    !(body instanceof FormData) &&
+    !(body instanceof URLSearchParams)
+  ) {
     headers.set('Content-Type', 'application/json');
     body = JSON.stringify(body);
   }


### PR DESCRIPTION
## Summary
- ensure LoginForm submits URLSearchParams as form data

## Testing
- `pytest -q` *(fails: 13 failed, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68446d78c3cc83318f5e014d93c13f22