### PR TITLE
Add admin settings management page

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ After logging in you will see the dashboard listing all items. Links are provide
 
 Admins can also open `/users` to manage accounts. The page lists existing users and includes a form to create new ones.
 
+A simple `/settings` page lets administrators store configuration values in the database. Use it to tweak options like notification settings without touching environment variables during testing.
+
 The latest UI introduces a sidebar driven dashboard where stock is organised by **department** and **category**. Users can create, edit and delete departments or categories, restock items or transfer them between departments, and scan barcodes to look up stock quickly. A history dialog records all actions so past movements can be reviewed.
 
 ### Frontend tests

--- a/alembic/versions/20240609_add_settings_table.py
+++ b/alembic/versions/20240609_add_settings_table.py
@@ -1,0 +1,25 @@
+"""add settings table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20240609_add_settings'
+down_revision = '20240608_remove_totp'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'settings',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('tenant_id', sa.Integer, sa.ForeignKey('tenants.id')),
+        sa.Column('key', sa.String, nullable=False),
+        sa.Column('value', sa.String, nullable=False),
+        sa.UniqueConstraint('tenant_id', 'key', name='uix_tenant_key'),
+    )
+
+
+def downgrade():
+    op.drop_table('settings')
+

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -103,3 +103,13 @@ export const deleteUser = (token: string, id: number) =>
     method: 'DELETE',
     body: { id },
   });
+
+// Settings
+export const getSettings = (token: string) =>
+  apiGet<Record<string, string>>('/settings?tenant_id=1');
+
+export const updateSettings = (token: string, data: Record<string, string>) =>
+  apiFetch<Record<string, string>>('/settings', {
+    method: 'PUT',
+    body: { tenant_id: 1, settings: data },
+  });

--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { getSettings, updateSettings } from '@/lib/api';
+import { useAuth } from '@/lib/auth-context';
+
+export default function SettingsPage() {
+  const router = useRouter();
+  const { token } = useAuth();
+  const [settings, setSettings] = useState<Record<string, string>>({});
+  const [key, setKey] = useState('');
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    if (!token) {
+      router.replace('/login');
+    } else {
+      getSettings(token).then(setSettings).catch(() => {});
+    }
+  }, [token, router]);
+
+  if (!token) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token) return;
+    const newSettings = { ...settings, [key]: value };
+    const updated = await updateSettings(token, newSettings);
+    setSettings(updated);
+    setKey('');
+    setValue('');
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Settings</h1>
+      <ul>
+        {Object.entries(settings).map(([k, v]) => (
+          <li key={k}>
+            {k}: {v}
+          </li>
+        ))}
+      </ul>
+      <form onSubmit={handleSubmit} style={{ marginTop: 20 }}>
+        <input
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          placeholder="key"
+        />
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="value"
+        />
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  );
+}
+

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ from routers.audit import router as audit_router
 from routers.departments import router as departments_router
 from routers.categories import router as categories_router
 from routers.items import router as items_router
+from routers.settings import router as settings_router
 from websocket_manager import InventoryWSManager
 from rate_limiter import RateLimiter
 
@@ -80,6 +81,7 @@ app.include_router(departments_router)
 app.include_router(categories_router)
 app.include_router(items_router)
 app.include_router(audit_router)
+app.include_router(settings_router)
 
 
 @app.websocket("/ws/inventory/{tenant_id}")

--- a/models.py
+++ b/models.py
@@ -13,6 +13,7 @@ class Tenant(Base):
 
     users = relationship("User", back_populates="tenant")
     items = relationship("Item", back_populates="tenant")
+    settings = relationship("Setting", back_populates="tenant")
 
 
 class Department(Base):
@@ -109,3 +110,17 @@ class PasswordResetToken(Base):
     expires_at = Column(DateTime)
 
     user = relationship("User")
+
+
+class Setting(Base):
+    __tablename__ = "settings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id"))
+    key = Column(String, nullable=False)
+    value = Column(String, nullable=False)
+
+    tenant = relationship("Tenant", back_populates="settings")
+
+    __table_args__ = (UniqueConstraint("tenant_id", "key", name="uix_tenant_key"),)
+

--- a/routers/settings.py
+++ b/routers/settings.py
@@ -1,0 +1,46 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from auth import require_role, ensure_tenant
+from database import get_db
+from models import Setting, User
+from schemas import SettingsUpdate
+
+router = APIRouter()
+
+admin_only = require_role(["admin"])
+
+
+@router.get("/settings", response_model=dict[str, str])
+def read_settings(
+    tenant_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_only),
+):
+    ensure_tenant(user, tenant_id)
+    settings = db.query(Setting).filter(Setting.tenant_id == tenant_id).all()
+    return {s.key: s.value for s in settings}
+
+
+@router.put("/settings", response_model=dict[str, str])
+def update_settings(
+    payload: SettingsUpdate,
+    db: Session = Depends(get_db),
+    user: User = Depends(admin_only),
+):
+    ensure_tenant(user, payload.tenant_id)
+    for key, value in payload.settings.items():
+        setting = (
+            db.query(Setting)
+            .filter(Setting.tenant_id == payload.tenant_id, Setting.key == key)
+            .first()
+        )
+        if setting:
+            setting.value = value
+        else:
+            setting = Setting(tenant_id=payload.tenant_id, key=key, value=value)
+            db.add(setting)
+    db.commit()
+    settings = db.query(Setting).filter(Setting.tenant_id == payload.tenant_id).all()
+    return {s.key: s.value for s in settings}
+

--- a/schemas.py
+++ b/schemas.py
@@ -170,6 +170,24 @@ class CategoryUpdate(BaseModel):
     icon: str | None = None
 
 
+class SettingBase(BaseModel):
+    key: str
+    value: str
+    tenant_id: int
+
+
+class SettingResponse(SettingBase):
+    id: int
+
+    if ConfigDict:
+        model_config = ConfigDict(from_attributes=True)
+
+
+class SettingsUpdate(BaseModel):
+    tenant_id: int
+    settings: dict[str, str]
+
+
 class PasswordResetRequest(BaseModel):
     username: str
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,19 @@
+from tests.conftest import get_token
+
+
+def test_update_and_get_settings(client):
+    token = get_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = client.put(
+        "/settings",
+        json={"tenant_id": 1, "settings": {"example": "value"}},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["example"] == "value"
+
+    resp = client.get("/settings", params={"tenant_id": 1}, headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["example"] == "value"
+


### PR DESCRIPTION
## Summary
- add settings table and API routes
- expose endpoints via FastAPI
- implement Next.js settings page
- update client API helpers
- document the new feature in README
- create Alembic migration and tests

## Testing
- `pytest tests/test_settings.py -q`
- `pytest -q` *(fails: KeyboardInterrupt after all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_684427e0360883319ceb3167b9f81d41