### PR TITLE
Update docs and agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,12 @@ This project uses a multi-agent approach to build a SaaS inventory platform.
   - API integration tests
   - Frontend behavior validation (basic test coverage)
 
+### 5. ⚙️ `ops-agent`
+- **Responsibilities**:
+  - Docker builds and Compose orchestration
+  - Manage Nginx configuration
+  - Provide helper scripts for local development
+
 ## Project Scope
 
 - Multi-tenant inventory system (each department manages its own stock)
@@ -55,9 +61,10 @@ This project uses a multi-agent approach to build a SaaS inventory platform.
 
 | Agent          | Status   | Notes                             |
 |----------------|----------|-----------------------------------|
-| backend-agent  | 🚧 WIP    | Base FastAPI routes in progress   |
-| frontend-agent | ⏳ Planned | V0.dev design coming next        |
-| analytics-agent| ❌ Not started | Data tracking not yet implemented |
-| test-agent     | ⏳ Planned | Unit testing planned after API v1 |
+| backend-agent  | ✅ Active | API and business logic implemented |
+| frontend-agent | 🚧 WIP    | Next.js dashboard under active development |
+| analytics-agent| 🚧 WIP    | CSV export and usage metrics available |
+| test-agent     | ✅ Active | Pytest and Playwright suites run in CI |
+| ops-agent      | ✅ Active | Docker and Nginx configuration maintained |
 
 Refer to [ROADMAP.md](ROADMAP.md) for prioritized features per agent.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ WebSocket notifications when stock levels drop.
 - Password reset endpoints (`/auth/request-reset` and `/auth/reset-password`)
 - Secrets can be loaded from an external JSON store
 - Next.js frontend located in the `frontend/` directory
+- Docker and Nginx configuration with a quickstart script
+- Comprehensive test suite using Pytest and Playwright
 
 You can use the CLI or the API to manage inventory. When available stock falls
 below a configured threshold, a warning is displayed during the status check.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,12 +13,16 @@ This document highlights major milestones for the inventory SaaS platform.
 - React/Next.js frontend dashboard and forms
 - Background tasks with Celery and WebSocket notifications
 - GitHub Actions CI and Docker/Nginx deployment
+- Password reset endpoints and user self-service
+- Rate limiting to protect authentication routes
+- Redis caching for analytics endpoints
 
 ## In Progress
-- Basic analytics graphs and dashboards
-- Extended integration tests and data factories
+- Expanded analytics dashboards with usage trends
+- Continuous integration of Playwright and Pytest suites
+- Helper scripts for local Docker workflows
 
 ## Planned
-- Password reset
-- Additional performance tuning and async optimisations
-- More notification options (email/Slack)
+- Two-factor authentication support
+- Further async optimisations for heavy workloads
+- Additional notification options (email/Slack)

--- a/alembic/AGENTS.md
+++ b/alembic/AGENTS.md
@@ -16,5 +16,6 @@ It is maintained by the **db-agent** (also referred to as the **backend-agent**)
   ```bash
   alembic upgrade head
   ```
-  Run this whenever the application starts on a new environment or when
-  deploying updates.
+Run this whenever the application starts on a new environment or when
+deploying updates. The `scripts/quickstart.sh` helper runs this automatically
+for Docker deployments.

--- a/checklist
+++ b/checklist
@@ -11,6 +11,11 @@ REST API	FastAPI endpoints for add/issue/return/status
 Departments & Categories       Manage stock groups and transfer items
 Registration Endpoint  Allow new user sign up
 WebSocket Alerts        Real-time low stock warnings
+Password Reset Endpoints      Self-service account recovery
+Rate Limiting  Protect auth and user management routes
+Analytics Endpoints   CSV export and basic usage dashboards
+Docker Quickstart     `scripts/quickstart.sh` builds containers
+Playwright Tests      End-to-end browser coverage
 1. Security & Authentication
 Expectation	Why it Matters
 ✅ Authenticated access (JWT) - implemented

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -14,4 +14,5 @@ This directory contains the Next.js interface managed by the **frontend-agent**.
 - Keep components simple and avoid heavy UI frameworks.
 - Before running Playwright tests, execute `npx playwright install` to download the required browser binaries. A helper script is available at `frontend/scripts/install_browsers.sh` and should be run from the `frontend` directory.
 - Run browser tests using `npx playwright test`.
+- Create a production build with `npm run build` before deploying.
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -14,4 +14,6 @@ These guidelines apply to the `scripts/` and `nginx/` directories.
 
 ## Quickstart
 
-Run `scripts/quickstart.sh` from the project root to build and launch all containers with `docker-compose`.
+Run `scripts/quickstart.sh` from the project root to build and launch all containers with `docker-compose`. This script also creates a `.env` file from `.env.example` if one does not exist.
+
+Use `scripts/rotate_secret.py` to generate a new `SECRET_KEY` in your configured secret store.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -10,4 +10,5 @@ This folder contains pytest suites driven by the **test-agent**.
 - Install Python dependencies from `requirements.txt`.
 - Execute all tests with `pytest` from the repository root.
 - Tests rely on an in-memory SQLite database and will not affect local data files.
+- Frontend behavior is checked with Playwright; run `npx playwright test` from the `frontend` directory after installing Node dependencies.
 


### PR DESCRIPTION
## Summary
- refresh agents overview and add ops agent
- list quickstart and testing features in README
- expand ROADMAP with recent milestones
- capture new features in project checklist
- note quickstart helper in ops documentation
- mention production build step and Playwright tests
- document automated Alembic migrations

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: 33 passed, 42 warnings in 203.64s)*


------
https://chatgpt.com/codex/tasks/task_e_68449911892c8331bc53fa0f22bbfea8