### PR TITLE
Improve login instructions and form

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ JWT tokens and basic role based access control (admin, manager, user).
 Credentials for the initial admin account are read from the environment
 variables `ADMIN_USERNAME` and `ADMIN_PASSWORD`. When running with the default
 SQLite database, missing values fall back to `admin`/`admin` for convenience.
+Use this username when signing in. Email addresses entered during registration
+are stored in the `username` column; there is no separate `email` field in the
+database.
 
 Inventory data is scoped by **tenant**. Every item and user belongs to a tenant
 record, identified by `tenant_id`. API requests must include this identifier so

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-stock}:${POSTGRES_PASSWORD:-stock}@db:5432/${POSTGRES_DB:-stockdb}
       SECRET_KEY: ${SECRET_KEY}
-      ADMIN_USERNAME: admin
-      ADMIN_PASSWORD: admin
+      ADMIN_USERNAME: ${ADMIN_USERNAME:-admin}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin}
     depends_on:
       - db
     ports:

--- a/frontend/components/LoginForm.tsx
+++ b/frontend/components/LoginForm.tsx
@@ -1,25 +1,27 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import Link from 'next/link';
-import { useAuth } from '@/lib/auth-context';
+import { useState } from "react";
+import Link from "next/link";
+import { useAuth } from "@/lib/auth-context";
 
 export default function LoginForm() {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const { login } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError('');
+    setError("");
     setIsLoading(true);
 
     try {
-      await login(email, password);
+      await login(username, password);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Login failed. Please try again.');
+      setError(
+        err instanceof Error ? err.message : "Login failed. Please try again.",
+      );
     } finally {
       setIsLoading(false);
     }
@@ -30,30 +32,36 @@ export default function LoginForm() {
       <h2 className="text-2xl font-bold mb-6 text-center text-gray-800">
         Stock Management Login
       </h2>
-      
+
       {error && (
         <div className="mb-4 p-3 bg-red-100 text-red-700 rounded-md text-sm">
           {error}
         </div>
       )}
-      
+
       <form onSubmit={handleSubmit}>
         <div className="mb-4">
-          <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
-            Email
+          <label
+            htmlFor="username"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Username
           </label>
           <input
-            id="email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
             required
           />
         </div>
-        
+
         <div className="mb-4">
-          <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+          <label
+            htmlFor="password"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
             Password
           </label>
           <input
@@ -70,20 +78,24 @@ export default function LoginForm() {
           type="submit"
           disabled={isLoading}
           className={`w-full py-2 px-4 rounded-md text-white font-medium 
-            ${isLoading 
-              ? 'bg-blue-400 cursor-not-allowed' 
-              : 'bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2'
+            ${
+              isLoading
+                ? "bg-blue-400 cursor-not-allowed"
+                : "bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
             }`}
         >
-          {isLoading ? 'Logging in...' : 'Log In'}
+          {isLoading ? "Logging in..." : "Log In"}
         </button>
 
         <div className="mt-4 text-center">
-          <Link href="/register" className="text-sm text-blue-600 hover:text-blue-800">
+          <Link
+            href="/register"
+            className="text-sm text-blue-600 hover:text-blue-800"
+          >
             Don't have an account? Register here
           </Link>
         </div>
       </form>
     </div>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- fix docker-compose to respect ADMIN_USERNAME and ADMIN_PASSWORD
- clarify README about using username for login
- tweak LoginForm to request username instead of email

## Testing
- `pytest -q`
- `npx playwright test` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_6844b73b04688331a38513ba764e7dac