### PR TITLE
Support username and email login

### DIFF
--- a/alembic/versions/20240609_add_email.py
+++ b/alembic/versions/20240609_add_email.py
@@ -1,0 +1,20 @@
+"""add email column to users"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20240609_add_email"
+down_revision = "20240608_remove_totp"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("users", sa.Column("email", sa.String(), nullable=True))
+    op.create_index(op.f("ix_users_email"), "users", ["email"], unique=True)
+
+
+def downgrade():
+    op.drop_index(op.f("ix_users_email"), table_name="users")
+    op.drop_column("users", "email")
+

--- a/auth.py
+++ b/auth.py
@@ -34,7 +34,9 @@ def get_password_hash(password):
 async def authenticate_user(
     db: AsyncSession, username: str, password: str
 ) -> Optional[User]:
-    result = await db.execute(select(User).where(User.username == username))
+    result = await db.execute(
+        select(User).where((User.username == username) | (User.email == username))
+    )
     user = result.scalars().first()
     if user and verify_password(password, user.hashed_password):
         return user

--- a/frontend/components/RegisterForm.tsx
+++ b/frontend/components/RegisterForm.tsx
@@ -8,6 +8,7 @@ import type { Department } from '@/types/stock';
 
 export default function RegisterForm() {
   const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [departmentId, setDepartmentId] = useState<number | ''>('');
@@ -49,6 +50,7 @@ export default function RegisterForm() {
     try {
       await apiPost('/auth/register', {
         email,
+        username,
         password,
         department_id: showDepartments && departmentId ? departmentId : null,
         is_admin: true // Default to admin user
@@ -85,6 +87,20 @@ export default function RegisterForm() {
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            required
+          />
+        </div>
+
+        <div className="mb-4">
+          <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-1">
+            Username
+          </label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
             className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
             required
           />

--- a/models.py
+++ b/models.py
@@ -65,6 +65,7 @@ class User(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String, unique=True, index=True)
+    email = Column(String, unique=True, index=True)
     hashed_password = Column(String)
     role = Column(String, default="user")
     tenant_id = Column(Integer, ForeignKey("tenants.id"))

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -19,7 +19,11 @@ router = APIRouter(prefix="/auth")
 
 @router.post("/register", response_model=RegisterResponse)
 def register(payload: RegisterRequest, db: Session = Depends(get_db)):
-    if db.query(User).filter(User.username == payload.email).first():
+    if (
+        db.query(User)
+        .filter((User.username == payload.username) | (User.email == payload.email))
+        .first()
+    ):
         raise HTTPException(status_code=400, detail="Username already registered")
 
     if payload.tenant_id is not None:
@@ -34,7 +38,8 @@ def register(payload: RegisterRequest, db: Session = Depends(get_db)):
 
     role = "admin" if payload.is_admin else "user"
     user = User(
-        username=payload.email,
+        username=payload.username,
+        email=payload.email,
         hashed_password=get_password_hash(payload.password),
         role=role,
         tenant_id=tenant.id,

--- a/routers/users.py
+++ b/routers/users.py
@@ -20,12 +20,16 @@ def create_user(
     ensure_tenant(user, payload.tenant_id)
     if (
         db.query(User)
-        .filter(User.username == payload.username, User.tenant_id == payload.tenant_id)
+        .filter(
+            (User.username == payload.username) | (User.email == payload.email),
+            User.tenant_id == payload.tenant_id,
+        )
         .first()
     ):
         raise HTTPException(status_code=400, detail="Username already registered")
     new_user = User(
         username=payload.username,
+        email=payload.email,
         hashed_password=get_password_hash(payload.password),
         role=payload.role,
         tenant_id=payload.tenant_id,
@@ -63,11 +67,16 @@ def update_user(
     if payload.username:
         if (
             db.query(User)
-            .filter(User.username == payload.username, User.id != payload.id)
+            .filter(
+                (User.username == payload.username) | (User.email == payload.email),
+                User.id != payload.id,
+            )
             .first()
         ):
             raise HTTPException(status_code=400, detail="Username already registered")
         user_obj.username = payload.username
+    if payload.email:
+        user_obj.email = payload.email
     if payload.password:
         user_obj.hashed_password = get_password_hash(payload.password)
     if payload.role:

--- a/schemas.py
+++ b/schemas.py
@@ -70,6 +70,7 @@ class TransferResponse(BaseModel):
 
 class UserBase(BaseModel):
     username: str
+    email: str
     notification_preference: str = "email"  # "email", "slack" or "none"
 
 
@@ -91,6 +92,7 @@ class UserResponse(UserBase):
 class UserUpdate(BaseModel):
     id: int
     username: str | None = None
+    email: str | None = None
     password: str | None = None
     role: str | None = None
     notification_preference: str | None = None
@@ -179,6 +181,7 @@ class PasswordResetConfirm(BaseModel):
 
 class RegisterRequest(BaseModel):
     email: str
+    username: str
     password: str
     tenant_id: int | None = None
     is_admin: bool = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,7 @@ def client():
             await adb.refresh(tenant)
             admin = User(
                 username="admin",
+                email="admin@example.com",
                 hashed_password=get_password_hash("admin"),
                 role="admin",
                 tenant_id=tenant.id,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,7 @@ def test_multi_tenant_isolation(client):
 
     admin2 = User(
         username="admin2",
+        email="admin2@example.com",
         hashed_password=get_password_hash("admin2"),
         role="admin",
         tenant_id=tenant2.id,
@@ -121,6 +122,7 @@ def test_create_user_duplicate_username(client):
     headers = {"Authorization": f"Bearer {token}"}
     payload = {
         "username": "dup",
+        "email": "dup@example.com",
         "password": "x",
         "role": "user",
         "tenant_id": 1,
@@ -139,6 +141,7 @@ def test_update_user_duplicate_username(client):
         "/users/",
         json={
             "username": "user1",
+            "email": "user1@example.com",
             "password": "a",
             "role": "user",
             "tenant_id": 1,
@@ -150,6 +153,7 @@ def test_update_user_duplicate_username(client):
         "/users/",
         json={
             "username": "user2",
+            "email": "user2@example.com",
             "password": "a",
             "role": "user",
             "tenant_id": 1,
@@ -253,16 +257,21 @@ def test_transfer_endpoint_and_history(client):
 def test_register_success(client):
     resp = client.post(
         "/auth/register",
-        json={"email": "new@example.com", "password": "secret", "is_admin": False},
+        json={
+            "email": "new@example.com",
+            "username": "newuser",
+            "password": "secret",
+            "is_admin": False,
+        },
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["user"]["username"] == "new@example.com"
+    assert data["user"]["username"] == "newuser"
     assert data["user"]["tenant_id"]
 
 
 def test_register_duplicate_username(client):
-    payload = {"email": "dup@example.com", "password": "x"}
+    payload = {"email": "dup@example.com", "username": "dupuser", "password": "x"}
     first = client.post("/auth/register", json=payload)
     assert first.status_code == 200
     second = client.post("/auth/register", json=payload)
@@ -272,6 +281,11 @@ def test_register_duplicate_username(client):
 def test_register_missing_tenant(client):
     resp = client.post(
         "/auth/register",
-        json={"email": "nodpt@example.com", "password": "pw", "tenant_id": 99},
+        json={
+            "email": "nodpt@example.com",
+            "username": "nodpt",
+            "password": "pw",
+            "tenant_id": 99,
+        },
     )
     assert resp.status_code == 404

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -31,18 +31,21 @@ def test_notification_logs_created():
         [
             User(
                 username="e1@example.com",
+                email="e1@example.com",
                 hashed_password="x",
                 tenant_id=1,
                 notification_preference="email",
             ),
             User(
                 username="s1@example.com",
+                email="s1@example.com",
                 hashed_password="x",
                 tenant_id=1,
                 notification_preference="slack",
             ),
             User(
                 username="n1@example.com",
+                email="n1@example.com",
                 hashed_password="x",
                 tenant_id=1,
                 notification_preference="none",

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -63,6 +63,7 @@ def client():
             await adb.refresh(tenant)
             admin = User(
                 username="admin",
+                email="admin@example.com",
                 hashed_password=get_password_hash("admin"),
                 role="admin",
                 tenant_id=tenant.id,
@@ -151,6 +152,7 @@ def test_websocket_transfer_notification(client):
     _session.refresh(dest)
     dest_user = User(
         username="dest_admin",
+        email="dest_admin@example.com",
         hashed_password=get_password_hash("dest"),
         role="admin",
         tenant_id=dest.id,
@@ -240,6 +242,7 @@ def test_user(db):
     # Create a test user
     user = User(
         username="test@example.com",
+        email="test@example.com",
         hashed_password="hashed_password",
         tenant_id=tenant.id,
     )
@@ -375,6 +378,7 @@ def test_websocket_tenant_isolation(client, test_user, test_item):
 
     user2 = User(
         username="test2@example.com",
+        email="test2@example.com",
         hashed_password="hashed_password",
         tenant_id=tenant2.id,
     )
@@ -532,6 +536,7 @@ def test_websocket_broadcast_to_all_tenants(client, test_user, test_item):
 
     user2 = User(
         username="test2@example.com",
+        email="test2@example.com",
         hashed_password="hashed_password",
         tenant_id=tenant2.id,
     )


### PR DESCRIPTION
## Summary
- add `email` column to user model and migration
- include email in user schemas and registration endpoint
- allow login via username or email
- update user CRUD endpoints and tests for email
- adjust registration form UI for username field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d001eff88331aa04cfb0b6488aae